### PR TITLE
Default GC setting update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## [2.1.0] TBD
+## [2.1.0] 2017-10-02
 ### Changed
+* Changed the default GC settings, tuning for our environment
 * Upgrade Hive from 2.1.0 to 2.3.0.
 * Depend on latest parent with test.arguments build parameter
 * Fixed bug where tunnel configuration wasn't being applied.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [2.1.0] 2017-10-02
 ### Changed
-* Changed the default GC settings, tuning for our environment
+* Changed the default GC settings, less heap, more reserved percentage, works better with large requests.
 * Upgrade Hive from 2.1.0 to 2.3.0.
 * Depend on latest parent with test.arguments build parameter
 * Fixed bug where tunnel configuration wasn't being applied.

--- a/waggle-dance/src/main/service/waggle-dance.conf
+++ b/waggle-dance/src/main/service/waggle-dance.conf
@@ -1,4 +1,4 @@
 #Spring boot service conf: see http://docs.spring.io/spring-boot/docs/current/reference/html/deployment-install.html#deployment-script-customization-conf-file
 LOG_FOLDER=/var/log/waggle-dance/
-JAVA_OPTS="-Xmx15g -XX:+UseG1GC -Dlog4j.configurationFile=/opt/waggle-dance/conf/log4j2.xml -Dlogging.config=/opt/waggle-dance/conf/log4j2.xml"
+JAVA_OPTS="-Xmx12g -XX:+UseG1GC -XX:G1ReservePercent=15 -Dlog4j.configurationFile=/opt/waggle-dance/conf/log4j2.xml -Dlogging.config=/opt/waggle-dance/conf/log4j2.xml"
 RUN_ARGS="--server-config=/opt/waggle-dance/conf/waggle-dance-server.yml --federation-config=/opt/waggle-dance/conf/waggle-dance-federation.yml"


### PR DESCRIPTION
changed gc settings, idea is to cope with bigger requests better

Lowered overal heap size to give more to OS and set XX:G1ReservePercent (default is 10), which I understand helps in preserving a bigger chunk before GC is called. 

