### PR TITLE
Updated versions of plugins and replaced deprecated methods and classes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ before_install:
 install:
   - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -P travis
 script:
-  - mvn clean install test cobertura:cobertura coveralls:report -B -P travis -DrepoToken=${COVERALLS_REPO_TOKEN} -Dtest.arguments="-Xmx1024m -XX:MaxPermSize=1024m -XX:PermSize=256m"
+  - mvn clean test cobertura:cobertura coveralls:report -B -P travis -DrepoToken=${COVERALLS_REPO_TOKEN} -Dtest.arguments="-Xmx1024m -XX:MaxPermSize=1024m -XX:PermSize=256m"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ before_install:
 install:
   - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -P travis
 script:
-  - mvn clean test cobertura:cobertura coveralls:report -B -P travis -DrepoToken=${COVERALLS_REPO_TOKEN} -Dtest.arguments="-Xmx1024m -XX:MaxPermSize=1024m -XX:PermSize=256m"
+  - mvn clean install test cobertura:cobertura coveralls:report -B -P travis -DrepoToken=${COVERALLS_REPO_TOKEN} -Dtest.arguments="-Xmx1024m -XX:MaxPermSize=1024m -XX:PermSize=256m"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # TBD
 ### Changed
 * Refactored general purpose Hive metastore code to leverage hcommon-hive-metastore and hcommon-ssh libraries. See [#78](https://github.com/HotelsDotCom/waggle-dance/issues/78).
+* Updated versions of dependencies and plugins in waggle-dance-parent, waggle-dance, waggle-dance-core and waggle-dance-rpm modules. 
+* Replaced deprecated methods and classes.
 
 ## [2.3.7] 2018-06-19
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Refactored general purpose Hive metastore code to leverage hcommon-hive-metastore and hcommon-ssh libraries. See [#78](https://github.com/HotelsDotCom/waggle-dance/issues/78).
 * Updated versions of dependencies and plugins in waggle-dance-parent, waggle-dance, waggle-dance-core and waggle-dance-rpm modules. 
 * Replaced deprecated methods and classes.
+* Upgraded default Hive version from 2.3.0 to 2.3.3.
 
 ## [2.3.7] 2018-06-19
 ### Fixed

--- a/pom.xml
+++ b/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>hotels-oss-parent</artifactId>
-    <version>2.2.0</version>
+    <version>2.3.0</version>
   </parent>
 
   <artifactId>waggle-dance-parent</artifactId>
-  <version>2.3.8-SNAPSHOT</version>
+  <version>2.4.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Waggle Dance Parent</name>
   <description>Hive Metastore federation service.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,6 @@
     <spring-platform.version>Brussels-SR5</spring-platform.version>
     <hadoop.version>2.7.2</hadoop.version>
     <hive.version>2.3.3</hive.version>
-    <!-- dropwizard.version>1.2.8</dropwizard.version-->
     <dropwizard.metrics.version>3.1.5</dropwizard.metrics.version>
     <aspectj-maven-plugin.version>1.9</aspectj-maven-plugin.version>
     <jdk.version>1.7</jdk.version>
@@ -55,13 +54,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <!-- dependency>
-        <groupId>io.dropwizard</groupId>
-        <artifactId>dropwizard-bom</artifactId>
-        <version>${dropwizard.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency-->
       <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-common</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>hotels-oss-parent</artifactId>
-    <version>2.0.6</version>
+    <version>2.2.0</version>
   </parent>
 
   <artifactId>waggle-dance-parent</artifactId>
@@ -32,17 +32,17 @@
   </modules>
 
   <properties>
-    <cobertura.version>2.0.3</cobertura.version>
-    <cobertura.maven.plugin.version>2.6</cobertura.maven.plugin.version>
+    <cobertura.version>2.1.1</cobertura.version>
+    <cobertura.maven.plugin.version>2.7</cobertura.maven.plugin.version>
     <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
     <spring-platform.version>Brussels-SR5</spring-platform.version>
     <hadoop.version>2.7.2</hadoop.version>
-    <hive.version>2.3.0</hive.version>
-    <dropwizard.version>1.0.5</dropwizard.version>
+    <hive.version>2.3.3</hive.version>
+    <dropwizard.version>1.3.5</dropwizard.version>
     <aspectj-maven-plugin.version>1.9</aspectj-maven-plugin.version>
     <jdk.version>1.7</jdk.version>
     <aspectj.version>1.8.9</aspectj.version>
-    <beeju.version>1.2.0</beeju.version>
+    <beeju.version>1.2.1</beeju.version>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,8 @@
     <spring-platform.version>Brussels-SR5</spring-platform.version>
     <hadoop.version>2.7.2</hadoop.version>
     <hive.version>2.3.3</hive.version>
-    <dropwizard.version>1.2.8</dropwizard.version>
+    <!-- dropwizard.version>1.2.8</dropwizard.version-->
+    <dropwizard.metrics.version>3.2.6</dropwizard.metrics.version>
     <aspectj-maven-plugin.version>1.9</aspectj-maven-plugin.version>
     <jdk.version>1.7</jdk.version>
     <aspectj.version>1.8.9</aspectj.version>
@@ -54,13 +55,13 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <dependency>
+      <!-- dependency>
         <groupId>io.dropwizard</groupId>
         <artifactId>dropwizard-bom</artifactId>
         <version>${dropwizard.version}</version>
         <type>pom</type>
         <scope>import</scope>
-      </dependency>
+      </dependency-->
       <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-common</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>hotels-oss-parent</artifactId>
-    <version>2.3.0</version>
+    <version>2.3.1</version>
   </parent>
 
   <artifactId>waggle-dance-parent</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <spring-platform.version>Brussels-SR5</spring-platform.version>
     <hadoop.version>2.7.2</hadoop.version>
     <hive.version>2.3.3</hive.version>
-    <dropwizard.version>1.3.5</dropwizard.version>
+    <dropwizard.version>1.2.8</dropwizard.version>
     <aspectj-maven-plugin.version>1.9</aspectj-maven-plugin.version>
     <jdk.version>1.7</jdk.version>
     <aspectj.version>1.8.9</aspectj.version>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <hadoop.version>2.7.2</hadoop.version>
     <hive.version>2.3.3</hive.version>
     <!-- dropwizard.version>1.2.8</dropwizard.version-->
-    <dropwizard.metrics.version>3.2.6</dropwizard.metrics.version>
+    <dropwizard.metrics.version>3.1.5</dropwizard.metrics.version>
     <aspectj-maven-plugin.version>1.9</aspectj-maven-plugin.version>
     <jdk.version>1.7</jdk.version>
     <aspectj.version>1.8.9</aspectj.version>

--- a/waggle-dance-api/pom.xml
+++ b/waggle-dance-api/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>waggle-dance-parent</artifactId>
-    <version>2.3.8-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>waggle-dance-api</artifactId>

--- a/waggle-dance-api/src/main/java/com/hotels/bdp/waggledance/api/model/AbstractMetaStore.java
+++ b/waggle-dance-api/src/main/java/com/hotels/bdp/waggledance/api/model/AbstractMetaStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Expedia Inc.
+ * Copyright (C) 2016-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "federationType")
@@ -135,7 +136,7 @@ public abstract class AbstractMetaStore {
 
   @Override
   public String toString() {
-    return Objects
+    return MoreObjects
         .toStringHelper(this)
         .add("name", name)
         .add("databasePrefix", databasePrefix)

--- a/waggle-dance-api/src/main/java/com/hotels/bdp/waggledance/api/validation/validator/TunnelRouteValidator.java
+++ b/waggle-dance-api/src/main/java/com/hotels/bdp/waggledance/api/validation/validator/TunnelRouteValidator.java
@@ -34,20 +34,20 @@ import com.hotels.bdp.waggledance.api.validation.constraint.TunnelRoute;
 
 /**
  * Inspired by Hibernate's {@link EmailValidator}, this class checks that a given character sequence (e.g.
- * {@link String}) is a well-formed list of hostnames, optionally preceded by a username, separated by "->", e.g.
- * "user1@host1 -> host2".
+ * {@link String}) is a well-formed list of hostnames, optionally preceded by a username, separated by "-&gt;", e.g.
+ * "user1@host1 -&gt; host2".
  * <p>
  * These are some examples of valid expressions:
- *
+ * </p>
+ * 
  * <pre>
  * my-host
  * another-host.co.uk
  * etluser@tenant-node.company.com
- * my-host -> another-host.co.uk
- * another-host.co.uk -> etluser@tenant-node.company.com
- * ec2-user@bastion-host -> hadoop@emr-master
+ * my-host -&gt; another-host.co.uk
+ * another-host.co.uk -&gt; etluser@tenant-node.company.com
+ * ec2-user@bastion-host -&gt; hadoop@emr-master
  * </pre>
- * </p>
  */
 public class TunnelRouteValidator implements ConstraintValidator<TunnelRoute, CharSequence> {
   private static final String ATOM = "[a-z0-9!#$%&'*+/=?^_`{|}~-]";
@@ -73,7 +73,7 @@ public class TunnelRouteValidator implements ConstraintValidator<TunnelRoute, Ch
 
   @Override
   public boolean isValid(CharSequence value, ConstraintValidatorContext context) {
-    if (value == null || value.toString().trim().length() == 0) {
+    if ((value == null) || (value.toString().trim().length() == 0)) {
       return true;
     }
 
@@ -105,7 +105,7 @@ public class TunnelRouteValidator implements ConstraintValidator<TunnelRoute, Ch
       // The regular expression match would take care of this, but IDN.toASCII drops the trailing '.'
       // (IMO a bug in the implementation)
 
-      if (username != null
+      if ((username != null)
           && (username.endsWith(".") || !matchPart(username.trim(), LOCAL_PATTERN, MAX_LOCAL_PART_LENGTH))) {
         return false;
       }
@@ -145,7 +145,7 @@ public class TunnelRouteValidator implements ConstraintValidator<TunnelRoute, Ch
         break;
       }
       start = end;
-      end = start + 63 > unicodeString.length() ? unicodeString.length() : start + 63;
+      end = (start + 63) > unicodeString.length() ? unicodeString.length() : start + 63;
     }
 
     return asciiString.toString();

--- a/waggle-dance-api/src/test/java/com/hotels/bdp/waggledance/api/validation/validator/TunnelRouteValidatorTest.java
+++ b/waggle-dance-api/src/test/java/com/hotels/bdp/waggledance/api/validation/validator/TunnelRouteValidatorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Expedia Inc.
+ * Copyright (C) 2016-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,6 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import com.hotels.bdp.waggledance.api.validation.constraint.TunnelRoute;
-import com.hotels.bdp.waggledance.api.validation.validator.TunnelRouteValidator;
 
 @RunWith(MockitoJUnitRunner.class)
 public class TunnelRouteValidatorTest {

--- a/waggle-dance-core/pom.xml
+++ b/waggle-dance-core/pom.xml
@@ -65,15 +65,17 @@
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
+      <version>${dropwizard.metrics.version}</version>
     </dependency>
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-graphite</artifactId>
+      <version>${dropwizard.metrics.version}</version>
     </dependency>
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-jvm</artifactId>
-      <version>3.1.5</version>
+      <version>${dropwizard.metrics.version}</version>
     </dependency>
 
     <!-- Guava -->

--- a/waggle-dance-core/pom.xml
+++ b/waggle-dance-core/pom.xml
@@ -4,14 +4,14 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>waggle-dance-parent</artifactId>
-    <version>2.3.8-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>waggle-dance-core</artifactId>
 
   <properties>
     <spring-boot-maven-plugin.version>1.5.7.RELEASE</spring-boot-maven-plugin.version>
-    <mockito.version>2.8.8</mockito.version>
+    <mockito.version>2.8.47</mockito.version>
     <powermock.version>1.7.4</powermock.version>
     <jcabi-aspects.version>0.22.6</jcabi-aspects.version>
     <hcommon-hive-metastore.version>1.1.0</hcommon-hive-metastore.version>

--- a/waggle-dance-core/pom.xml
+++ b/waggle-dance-core/pom.xml
@@ -11,8 +11,8 @@
 
   <properties>
     <spring-boot-maven-plugin.version>1.5.7.RELEASE</spring-boot-maven-plugin.version>
-    <mockito.version>1.10.19</mockito.version>
-    <powermock.version>1.6.4</powermock.version>
+    <mockito.version>2.8.8</mockito.version>
+    <powermock.version>1.7.4</powermock.version>
     <jcabi-aspects.version>0.22.6</jcabi-aspects.version>
     <hcommon-hive-metastore.version>1.1.0</hcommon-hive-metastore.version>
   </properties>
@@ -251,7 +251,7 @@
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito</artifactId>
+      <artifactId>powermock-api-mockito2</artifactId>
       <version>${powermock.version}</version>
       <scope>test</scope>
     </dependency>

--- a/waggle-dance-core/pom.xml
+++ b/waggle-dance-core/pom.xml
@@ -73,6 +73,7 @@
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-jvm</artifactId>
+      <version>3.1.5</version>
     </dependency>
 
     <!-- Guava -->

--- a/waggle-dance-core/pom.xml
+++ b/waggle-dance-core/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -67,11 +68,11 @@
     </dependency>
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
-      <artifactId>metrics-jvm</artifactId>
+      <artifactId>metrics-graphite</artifactId>
     </dependency>
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
-      <artifactId>metrics-graphite</artifactId>
+      <artifactId>metrics-jvm</artifactId>
     </dependency>
 
     <!-- Guava -->
@@ -291,7 +292,7 @@
         <configuration>
           <requiresUnpack>
             <!-- We are hitting an issue introduced in hive-common-2.1.1 and fixed in https://issues.apache.org/jira/browse/HIVE-17155
-              The HiveConf class tries loading conf (e.g. hive-site.xml) from the uberjar and fails. Unpacking it with this 
+              The HiveConf class tries loading conf (e.g. hive-site.xml) from the uberjar and fails. Unpacking it with this
               setting fixes that problem.
             -->
             <dependency>

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/conf/GraphiteConfiguration.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/conf/GraphiteConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Expedia Inc.
+ * Copyright (C) 2016-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ public class GraphiteConfiguration {
 
   @PostConstruct
   void init() {
-    if (host != null || prefix != null) {
+    if ((host != null) || (prefix != null)) {
       enabled = true;
     }
   }

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/model/MetaStoreMapping.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/model/MetaStoreMapping.java
@@ -55,9 +55,9 @@ public interface MetaStoreMapping extends Closeable {
    *          have been stripped already)
    * @throws NotAllowedException when the metastore mapped by this class does not have the correct permission otherwise
    *           calls getClient().create_database(database)
-   * @throws TException Thrift exception
-   * @throws MetaException Hive exception
-   * @throws InvalidObjectException Hive exception
+   * @throws TException if a Thrift error occurs
+   * @throws MetaException if a problem occurs interacting with the Hive MetaStore
+   * @throws InvalidObjectException if Hive considers the database invalid
    * @throws AlreadyExistsException if the database already exists
    */
   void createDatabase(Database database)

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/model/MetaStoreMapping.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/model/MetaStoreMapping.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Expedia Inc.
+ * Copyright (C) 2016-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,14 +51,14 @@ public interface MetaStoreMapping extends Closeable {
   MetaStoreMapping checkWritePermissions(String databaseName);
 
   /**
-   * @param database (assummed to be the database used in this mapped metastore so any waggle dance related prefix must
+   * @param database (assumed to be the database used in this mapped metastore so any waggle dance related prefix must
    *          have been stripped already)
-   * @return throws {@link NotAllowedException} when the metastore mapped by this class does not have the correct
-   *         permission otherwise calls {{@link #getClient().create_database(database)}
-   * @throws TException
-   * @throws MetaException
-   * @throws InvalidObjectException
-   * @throws AlreadyExistsException
+   * @throws NotAllowedException when the metastore mapped by this class does not have the correct permission otherwise
+   *           calls getClient().create_database(database)
+   * @throws TException Thrift exception
+   * @throws MetaException Hive exception
+   * @throws InvalidObjectException Hive exception
+   * @throws AlreadyExistsException if the database already exists
    */
   void createDatabase(Database database)
     throws AlreadyExistsException, InvalidObjectException, MetaException, TException;

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/model/QueryMapping.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/model/QueryMapping.java
@@ -20,10 +20,10 @@ import com.hotels.bdp.waggledance.api.WaggleDanceException;
 public interface QueryMapping {
 
   /**
-   * @param metaStoreMapping
-   * @param query
+   * @param metaStoreMapping the mapping for the transformation
+   * @param query the query to be transformed
    * @return query where database names are correctly mapped using metaStoreMapping. example 'select id from db.table'
-   *         -> 'select id from waggle_db.table'
+   *         -&gt; 'select id from waggle_db.table'
    * @throws WaggleDanceException when the transform could not be done.
    */
   String transformOutboundDatabaseName(MetaStoreMapping metaStoreMapping, String query) throws WaggleDanceException;

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/service/DatabaseMappingService.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/service/DatabaseMappingService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Expedia Inc.
+ * Copyright (C) 2016-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ public interface DatabaseMappingService extends Closeable {
   DatabaseMapping primaryDatabaseMapping();
 
   /**
+   * @param databaseName given database name
    * @return the {@link DatabaseMapping} that maps to the given databaseName
    */
   DatabaseMapping databaseMapping(@NotNull String databaseName);

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/service/PanopticOperationHandler.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/service/PanopticOperationHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Expedia Inc.
+ * Copyright (C) 2016-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,21 +27,34 @@ public interface PanopticOperationHandler {
 
   /**
    * Implements {@link HMSHandler#get_all_databases()} over multiple metastores
+   *
+   * @return list of all databases
    */
   List<String> getAllDatabases();
 
   /**
    * Implements {@link HMSHandler#get_database(String)} over multiple metastores
+   *
+   * @param databasePattern pattern
+   * @return list of all databases with a pattern
    */
   List<String> getAllDatabases(String databasePattern);
 
   /**
    * Implements {@link HMSHandler#get_table_meta(String, String, List)} over multiple metastores
+   *
+   * @param databasePatterns database patterns
+   * @param tablePatterns table patterns
+   * @return list of table metadata
    */
   List<TableMeta> getTableMeta(String databasePatterns, String tablePatterns, List<String> tableTypes);
 
   /**
    * Implements {@link HMSHandler#set_ugi(String, List)} over multiple metastores
+   *
+   * @param user_name user name
+   * @param group_names group names
+   * @return list
    */
   List<String> setUgi(String user_name, List<String> group_names);
 

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/service/PanopticOperationHandler.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/service/PanopticOperationHandler.java
@@ -35,16 +35,17 @@ public interface PanopticOperationHandler {
   /**
    * Implements {@link HMSHandler#get_database(String)} over multiple metastores
    *
-   * @param databasePattern pattern
-   * @return list of all databases with a pattern
+   * @param databasePattern pattern to match
+   * @return list of all databases that match the passed pattern
    */
   List<String> getAllDatabases(String databasePattern);
 
   /**
    * Implements {@link HMSHandler#get_table_meta(String, String, List)} over multiple metastores
    *
-   * @param databasePatterns database patterns
-   * @param tablePatterns table patterns
+   * @param databasePatterns database patterns to match
+   * @param tablePatterns table patterns to match
+   * @param tableTypes table types to match
    * @return list of table metadata
    */
   List<TableMeta> getTableMeta(String databasePatterns, String tablePatterns, List<String> tableTypes);

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/service/impl/SimpleFederationStatusService.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/service/impl/SimpleFederationStatusService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Expedia Inc.
+ * Copyright (C) 2016-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ public class SimpleFederationStatusService implements FederationStatusService {
    * increases impacting the performance of the server then caching or an alternative solution could be adopted.
    * </p>
    *
-   * @param metaStoreUris URI of the metastore to check.
+   * @param abstractMetaStore the metastore to check
    * @return {@code MetaStoreStatus.AVAILABLE} if the service can successfully connect to the metastore. Otherwise,
    *         returns {@code MetaStoreStatus.UNAVAILABLE}
    */

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/server/security/AccessControlHandler.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/server/security/AccessControlHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Expedia Inc.
+ * Copyright (C) 2016-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package com.hotels.bdp.waggledance.server.security;
 public interface AccessControlHandler {
 
   /**
-   * @param databaseName
+   * @param databaseName name of the database
    * @return true if databaseName is writable, false otherwise
    */
   boolean hasWritePermission(String databaseName);

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/client/CloseableThriftHiveMetastoreIfaceClientFactoryTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/client/CloseableThriftHiveMetastoreIfaceClientFactoryTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.waggledance.api.model.AbstractMetaStore;
 import com.hotels.bdp.waggledance.api.model.MetastoreTunnel;

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/client/ThriftMetastoreClientTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/client/ThriftMetastoreClientTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Expedia Inc.
+ * Copyright (C) 2016-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @RunWith(MockitoJUnitRunner.class)

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/client/TunnelingMetaStoreClientFactoryTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/client/TunnelingMetaStoreClientFactoryTest.java
@@ -15,9 +15,9 @@
  */
 package com.hotels.bdp.waggledance.client;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
@@ -31,7 +31,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.beeju.ThriftHiveMetaStoreJUnitRule;
 import com.hotels.hcommon.ssh.TunnelableFactory;

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/model/ASTQueryMappingTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/model/ASTQueryMappingTest.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.waggledance.api.WaggleDanceException;
 

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/model/DatabaseMappingImplTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/model/DatabaseMappingImplTest.java
@@ -73,7 +73,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import jersey.repackaged.com.google.common.collect.Lists;
 

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/model/IdentityMappingTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/model/IdentityMappingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Expedia Inc.
+ * Copyright (C) 2016-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package com.hotels.bdp.waggledance.mapping.model;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -66,7 +66,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class IdentityMappingTest {

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/model/MetaStoreMappingFactoryImplTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/model/MetaStoreMappingFactoryImplTest.java
@@ -18,7 +18,7 @@ package com.hotels.bdp.waggledance.mapping.model;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -34,7 +34,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 
 import com.hotels.bdp.waggledance.api.model.AbstractMetaStore;
@@ -63,7 +63,7 @@ public class MetaStoreMappingFactoryImplTest {
     when(prefixNamingStrategy.apply(any(AbstractMetaStore.class))).thenAnswer(new Answer<String>() {
       @Override
       public String answer(InvocationOnMock invocation) throws Throwable {
-        return invocation.getArgumentAt(0, AbstractMetaStore.class).getDatabasePrefix();
+        return ((AbstractMetaStore) invocation.getArgument(0)).getDatabasePrefix();
       }
     });
     factory = new MetaStoreMappingFactoryImpl(prefixNamingStrategy, metaStoreClientFactory,

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/model/MetaStoreMappingImplTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/model/MetaStoreMappingImplTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Expedia Inc.
+ * Copyright (C) 2016-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.waggledance.client.CloseableThriftHiveMetastoreIface;
 import com.hotels.bdp.waggledance.server.security.AccessControlHandler;

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/service/impl/MonitoredDatabaseMappingServiceTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/service/impl/MonitoredDatabaseMappingServiceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Expedia Inc.
+ * Copyright (C) 2016-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.waggledance.api.model.AbstractMetaStore;
 import com.hotels.bdp.waggledance.mapping.model.DatabaseMapping;

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/service/impl/NotifyingFederationServiceTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/service/impl/NotifyingFederationServiceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Expedia Inc.
+ * Copyright (C) 2016-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.waggledance.api.model.AbstractMetaStore;
 import com.hotels.bdp.waggledance.mapping.service.FederatedMetaStoreStorage;

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/service/impl/PrefixBasedDatabaseMappingServiceTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/service/impl/PrefixBasedDatabaseMappingServiceTest.java
@@ -40,7 +40,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import jersey.repackaged.com.google.common.collect.Lists;
 

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/service/impl/SimpleFederationStatusServiceTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/service/impl/SimpleFederationStatusServiceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Expedia Inc.
+ * Copyright (C) 2016-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.waggledance.api.model.FederatedMetaStore;
 import com.hotels.bdp.waggledance.api.model.MetaStoreStatus;

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/service/impl/StaticDatabaseMappingServiceTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/service/impl/StaticDatabaseMappingServiceTest.java
@@ -40,7 +40,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import jersey.repackaged.com.google.common.collect.Lists;
 

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/service/impl/YamlFederatedMetaStoreStorageTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/service/impl/YamlFederatedMetaStoreStorageTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Expedia Inc.
+ * Copyright (C) 2016-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import fm.last.commons.test.file.ClassDataFolder;
 import fm.last.commons.test.file.DataFolder;

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/metrics/MonitoredAspectTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/metrics/MonitoredAspectTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Expedia Inc.
+ * Copyright (C) 2016-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.boot.actuate.metrics.CounterService;
 import org.springframework.boot.actuate.metrics.GaugeService;
 

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/server/ExceptionWrappingHMSHandlerTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/server/ExceptionWrappingHMSHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Expedia Inc.
+ * Copyright (C) 2016-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.waggledance.server.security.NotAllowedException;
 

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/server/FederatedHMSHandlerFactoryTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/server/FederatedHMSHandlerFactoryTest.java
@@ -27,7 +27,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.waggledance.api.model.AbstractMetaStore;
 import com.hotels.bdp.waggledance.api.model.DatabaseResolution;

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/server/FederatedHMSHandlerTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/server/FederatedHMSHandlerTest.java
@@ -68,7 +68,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.google.common.collect.Lists;
 

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/server/TSetIpAddressProcessorFactoryTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/server/TSetIpAddressProcessorFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Expedia Inc.
+ * Copyright (C) 2016-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class TSetIpAddressProcessorFactoryTest {

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/server/TTransportMonitorTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/server/TTransportMonitorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Expedia Inc.
+ * Copyright (C) 2016-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.waggledance.conf.WaggleDanceConfiguration;
 

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/server/security/AccessControlHandlerFactoryTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/server/security/AccessControlHandlerFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Expedia Inc.
+ * Copyright (C) 2016-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.waggledance.api.federation.service.FederationService;
 import com.hotels.bdp.waggledance.api.model.AccessControlType;

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/server/security/DatabaseWhitelistAccessControlHandlerTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/server/security/DatabaseWhitelistAccessControlHandlerTest.java
@@ -33,7 +33,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.waggledance.api.federation.service.FederationService;
 import com.hotels.bdp.waggledance.api.model.PrimaryMetaStore;

--- a/waggle-dance-integration-tests/README.md
+++ b/waggle-dance-integration-tests/README.md
@@ -1,0 +1,21 @@
+## Running the integration tests
+
+Generally the integration tests should "just work" when run via Maven on the command line and in an IDE. However we have seen issues where there is an 
+interaction between Dropwizard metrics classes (e.g. if you modify the version in use) and the AspectJ code and the Maven plugin we use to add monitoring to 
+the `FederatedHMSHandler`. This manifests itself in tests that pass on the command line but fail in the IDE, usually with a failure like
+
+    [ERROR] Failures: 
+    [ERROR] WaggleDanceIntegrationTest.typicalWithGraphite:275->assertMetric:295 Metric 'graphitePrefix.counter.com.hotels.bdp.waggledance.server.FederatedHMSHandler.get_all_databases.all.calls.count 2' not found
+
+This indicates that the weaving of the Aspect hasn't been activated in the IDE. One solution to this is to do the weaving using Maven on the command line 
+and then re-run the tests in the IDE. The following steps should achieve that: 
+
+1. Run `mvn -DskipTests install` in the top-level Waggle Dance parent project (this should weave the aspects using the Maven plugin and generate the 
+correct class files).
+2. Refresh the project in the IDE (this should get the IDE to pick up the above classes).
+3. Run the integration tests (which should now pass!)
+
+## Legal
+This project is available under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0.html).
+
+Copyright 2016-2018 Expedia Inc.

--- a/waggle-dance-integration-tests/pom.xml
+++ b/waggle-dance-integration-tests/pom.xml
@@ -20,6 +20,20 @@
       <artifactId>waggle-dance-core</artifactId>
       <version>${project.version}</version>
     </dependency>
+    
+    <!-- Dropwizard -->
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-graphite</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-jvm</artifactId>
+    </dependency>
 
     <!-- Hive -->
     <dependency>

--- a/waggle-dance-integration-tests/pom.xml
+++ b/waggle-dance-integration-tests/pom.xml
@@ -33,6 +33,7 @@
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-jvm</artifactId>
+      <version>3.1.5</version>
     </dependency>
 
     <!-- Hive -->

--- a/waggle-dance-integration-tests/pom.xml
+++ b/waggle-dance-integration-tests/pom.xml
@@ -25,15 +25,17 @@
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
+      <version>${dropwizard.metrics.version}</version>
     </dependency>
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-graphite</artifactId>
+      <version>${dropwizard.metrics.version}</version>
     </dependency>
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-jvm</artifactId>
-      <version>3.1.5</version>
+      <version>${dropwizard.metrics.version}</version>
     </dependency>
 
     <!-- Hive -->

--- a/waggle-dance-integration-tests/pom.xml
+++ b/waggle-dance-integration-tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>waggle-dance-parent</artifactId>
-    <version>2.3.8-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>waggle-dance-integration-tests</artifactId>

--- a/waggle-dance-rest/pom.xml
+++ b/waggle-dance-rest/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>waggle-dance-parent</artifactId>
-    <version>2.3.8-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>waggle-dance-rest</artifactId>

--- a/waggle-dance-rpm/pom.xml
+++ b/waggle-dance-rpm/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>waggle-dance-parent</artifactId>
-    <version>2.3.8-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>waggle-dance-rpm</artifactId>

--- a/waggle-dance-rpm/pom.xml
+++ b/waggle-dance-rpm/pom.xml
@@ -13,7 +13,7 @@
 
   <properties>
     <tmp.directory>${project.build.directory}/tmp-directory</tmp.directory>
-    <rpm.maven.plugin.version>2.1.5</rpm.maven.plugin.version>
+    <rpm.maven.plugin.version>2.2.0</rpm.maven.plugin.version>
     <rpm-sources.directory>${tmp.directory}/waggle-dance-${project.version}</rpm-sources.directory>
     <rpm.install.dir>/opt/waggle-dance</rpm.install.dir>
     <rpm.install.user>waggle-dance</rpm.install.user>

--- a/waggle-dance/pom.xml
+++ b/waggle-dance/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>com.hotels</groupId>
     <artifactId>waggle-dance-parent</artifactId>
-    <version>2.3.8-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>waggle-dance</artifactId>

--- a/waggle-dance/pom.xml
+++ b/waggle-dance/pom.xml
@@ -12,7 +12,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <maven-assembly-plugin.version>3.0.0</maven-assembly-plugin.version>
+    <maven-assembly-plugin.version>3.1.0</maven-assembly-plugin.version>
     <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
     <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
     <artifact.location>${project.build.directory}/waggle-dance-${project.version}-bin.tgz</artifact.location>


### PR DESCRIPTION
The version of Mockito that seems to work with the lastest version of Powermock(1.7.4) is 2.8.8, and the latest one in Maven Central is 2.8.47([https://github.com/powermock/powermock/wiki/Mockito](url)).
Since org.mockito.runners.MockitoJUnitRunner is deprecated, I replaced it with org.mockito.junit.MockitoJUnitRunner, the same with some other methods.
