### PR TITLE
Issue 115, performance degradation addressed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 [TBD] TBD
 ### Changed
+* Removed performance hit we get from checking if a connection is alive for non tunnelled connections. See [#115](https://github.com/HotelsDotCom/waggle-dance/issues/115).
 * Updated `hotels-oss-parent` to version 2.3.3 (was 2.3.2).
 
 [2.4.0] 2018-07-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 [TBD] TBD
 ### Changed
-* Removed performance hit we get from checking if a connection is alive for non tunnelled connections. See [#115](https://github.com/HotelsDotCom/waggle-dance/issues/115).
+* Removed performance hit we get from checking if a connection is alive for non-tunnelled connections. See [#115](https://github.com/HotelsDotCom/waggle-dance/issues/115).
 * Updated `hotels-oss-parent` to version 2.3.3 (was 2.3.2).
 
 [2.4.0] 2018-07-27

--- a/waggle-dance-api/src/main/java/com/hotels/bdp/waggledance/api/model/AbstractMetaStore.java
+++ b/waggle-dance-api/src/main/java/com/hotels/bdp/waggledance/api/model/AbstractMetaStore.java
@@ -15,12 +15,15 @@
  */
 package com.hotels.bdp.waggledance.api.model;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
+import static com.hotels.bdp.waggledance.api.model.ConnectionType.DIRECT_CONNECTION;
+import static com.hotels.bdp.waggledance.api.model.ConnectionType.TUNNELED;
 
 import java.beans.Transient;
 import java.util.Collections;
 import java.util.List;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 
 import org.hibernate.validator.constraints.NotBlank;
 
@@ -111,6 +114,13 @@ public abstract class AbstractMetaStore {
     this.metastoreTunnel = metastoreTunnel;
   }
 
+  public ConnectionType getConnectionType() {
+    if (getMetastoreTunnel() != null) {
+      return TUNNELED;
+    }
+    return DIRECT_CONNECTION;
+  }
+
   abstract public FederationType getFederationType();
 
   public AccessControlType getAccessControlType() {
@@ -173,5 +183,4 @@ public abstract class AbstractMetaStore {
         .add("status", status)
         .toString();
   }
-
 }

--- a/waggle-dance-api/src/main/java/com/hotels/bdp/waggledance/api/model/AbstractMetaStore.java
+++ b/waggle-dance-api/src/main/java/com/hotels/bdp/waggledance/api/model/AbstractMetaStore.java
@@ -15,7 +15,7 @@
  */
 package com.hotels.bdp.waggledance.api.model;
 
-import static com.hotels.bdp.waggledance.api.model.ConnectionType.DIRECT_CONNECTION;
+import static com.hotels.bdp.waggledance.api.model.ConnectionType.DIRECT;
 import static com.hotels.bdp.waggledance.api.model.ConnectionType.TUNNELED;
 
 import java.beans.Transient;
@@ -118,7 +118,7 @@ public abstract class AbstractMetaStore {
     if (getMetastoreTunnel() != null) {
       return TUNNELED;
     }
-    return DIRECT_CONNECTION;
+    return DIRECT;
   }
 
   abstract public FederationType getFederationType();

--- a/waggle-dance-api/src/main/java/com/hotels/bdp/waggledance/api/model/ConnectionType.java
+++ b/waggle-dance-api/src/main/java/com/hotels/bdp/waggledance/api/model/ConnectionType.java
@@ -18,5 +18,4 @@ package com.hotels.bdp.waggledance.api.model;
 public enum ConnectionType {
   DIRECT_CONNECTION,
   TUNNELED;
-
 }

--- a/waggle-dance-api/src/main/java/com/hotels/bdp/waggledance/api/model/ConnectionType.java
+++ b/waggle-dance-api/src/main/java/com/hotels/bdp/waggledance/api/model/ConnectionType.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) 2016-2018 Expedia Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hotels.bdp.waggledance.api.model;
+
+public enum ConnectionType {
+  DIRECT_CONNECTION,
+  TUNNELED;
+
+}

--- a/waggle-dance-api/src/main/java/com/hotels/bdp/waggledance/api/model/ConnectionType.java
+++ b/waggle-dance-api/src/main/java/com/hotels/bdp/waggledance/api/model/ConnectionType.java
@@ -16,6 +16,6 @@
 package com.hotels.bdp.waggledance.api.model;
 
 public enum ConnectionType {
-  DIRECT_CONNECTION,
+  DIRECT,
   TUNNELED;
 }

--- a/waggle-dance-api/src/test/java/com/hotels/bdp/waggledance/api/model/FederatedMetaStoreTest.java
+++ b/waggle-dance-api/src/test/java/com/hotels/bdp/waggledance/api/model/FederatedMetaStoreTest.java
@@ -18,9 +18,9 @@ package com.hotels.bdp.waggledance.api.model;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-import javax.validation.ConstraintViolation;
-
 import java.util.Set;
+
+import javax.validation.ConstraintViolation;
 
 import org.junit.Test;
 
@@ -71,7 +71,7 @@ public class FederatedMetaStoreTest extends AbstractMetaStoreTest<FederatedMetaS
 
   @Test
   public void toJson() throws Exception {
-    String expected = "{\"accessControlType\":\"READ_ONLY\",\"databasePrefix\":\"name_\",\"federationType\":\"FEDERATED\",\"mappedDatabases\":[],\"metastoreTunnel\":null,\"name\":\"name\",\"remoteMetaStoreUris\":\"uri\",\"status\":\"UNKNOWN\",\"writableDatabaseWhiteList\":[]}";
+    String expected = "{\"accessControlType\":\"READ_ONLY\",\"connectionType\":\"DIRECT_CONNECTION\",\"databasePrefix\":\"name_\",\"federationType\":\"FEDERATED\",\"mappedDatabases\":[],\"metastoreTunnel\":null,\"name\":\"name\",\"remoteMetaStoreUris\":\"uri\",\"status\":\"UNKNOWN\",\"writableDatabaseWhiteList\":[]}";
     ObjectMapper mapper = new ObjectMapper();
     // Sorting to get deterministic test behaviour
     mapper.enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY);

--- a/waggle-dance-api/src/test/java/com/hotels/bdp/waggledance/api/model/FederatedMetaStoreTest.java
+++ b/waggle-dance-api/src/test/java/com/hotels/bdp/waggledance/api/model/FederatedMetaStoreTest.java
@@ -71,7 +71,7 @@ public class FederatedMetaStoreTest extends AbstractMetaStoreTest<FederatedMetaS
 
   @Test
   public void toJson() throws Exception {
-    String expected = "{\"accessControlType\":\"READ_ONLY\",\"connectionType\":\"DIRECT_CONNECTION\",\"databasePrefix\":\"name_\",\"federationType\":\"FEDERATED\",\"mappedDatabases\":[],\"metastoreTunnel\":null,\"name\":\"name\",\"remoteMetaStoreUris\":\"uri\",\"status\":\"UNKNOWN\",\"writableDatabaseWhiteList\":[]}";
+    String expected = "{\"accessControlType\":\"READ_ONLY\",\"connectionType\":\"DIRECT\",\"databasePrefix\":\"name_\",\"federationType\":\"FEDERATED\",\"mappedDatabases\":[],\"metastoreTunnel\":null,\"name\":\"name\",\"remoteMetaStoreUris\":\"uri\",\"status\":\"UNKNOWN\",\"writableDatabaseWhiteList\":[]}";
     ObjectMapper mapper = new ObjectMapper();
     // Sorting to get deterministic test behaviour
     mapper.enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY);

--- a/waggle-dance-api/src/test/java/com/hotels/bdp/waggledance/api/model/PrimaryMetaStoreTest.java
+++ b/waggle-dance-api/src/test/java/com/hotels/bdp/waggledance/api/model/PrimaryMetaStoreTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2017 Expedia Inc.
+ * Copyright (C) 2016-2018 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,7 +82,7 @@ public class PrimaryMetaStoreTest extends AbstractMetaStoreTest<PrimaryMetaStore
 
   @Test
   public void toJson() throws Exception {
-    String expected = "{\"accessControlType\":\"READ_ONLY\",\"databasePrefix\":\"\",\"federationType\":\"PRIMARY\",\"metastoreTunnel\":null,\"name\":\"name\",\"remoteMetaStoreUris\":\"uri\",\"status\":\"UNKNOWN\",\"writableDatabaseWhiteList\":[]}";
+    String expected = "{\"accessControlType\":\"READ_ONLY\",\"connectionType\":\"DIRECT_CONNECTION\",\"databasePrefix\":\"\",\"federationType\":\"PRIMARY\",\"metastoreTunnel\":null,\"name\":\"name\",\"remoteMetaStoreUris\":\"uri\",\"status\":\"UNKNOWN\",\"writableDatabaseWhiteList\":[]}";
     ObjectMapper mapper = new ObjectMapper();
     // Sorting to get deterministic test behaviour
     mapper.enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY);

--- a/waggle-dance-api/src/test/java/com/hotels/bdp/waggledance/api/model/PrimaryMetaStoreTest.java
+++ b/waggle-dance-api/src/test/java/com/hotels/bdp/waggledance/api/model/PrimaryMetaStoreTest.java
@@ -82,7 +82,7 @@ public class PrimaryMetaStoreTest extends AbstractMetaStoreTest<PrimaryMetaStore
 
   @Test
   public void toJson() throws Exception {
-    String expected = "{\"accessControlType\":\"READ_ONLY\",\"connectionType\":\"DIRECT_CONNECTION\",\"databasePrefix\":\"\",\"federationType\":\"PRIMARY\",\"metastoreTunnel\":null,\"name\":\"name\",\"remoteMetaStoreUris\":\"uri\",\"status\":\"UNKNOWN\",\"writableDatabaseWhiteList\":[]}";
+    String expected = "{\"accessControlType\":\"READ_ONLY\",\"connectionType\":\"DIRECT\",\"databasePrefix\":\"\",\"federationType\":\"PRIMARY\",\"metastoreTunnel\":null,\"name\":\"name\",\"remoteMetaStoreUris\":\"uri\",\"status\":\"UNKNOWN\",\"writableDatabaseWhiteList\":[]}";
     ObjectMapper mapper = new ObjectMapper();
     // Sorting to get deterministic test behaviour
     mapper.enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY);

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/client/CloseableThriftHiveMetastoreIfaceClientFactory.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/client/CloseableThriftHiveMetastoreIfaceClientFactory.java
@@ -15,6 +15,8 @@
  */
 package com.hotels.bdp.waggledance.client;
 
+import static com.hotels.bdp.waggledance.api.model.ConnectionType.TUNNELED;
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collections;
@@ -43,17 +45,18 @@ public class CloseableThriftHiveMetastoreIfaceClientFactory {
     Map<String, String> properties = new HashMap<>();
     String uris = normaliseMetaStoreUris(metaStore.getRemoteMetaStoreUris());
     String name = metaStore.getName().toLowerCase();
-    MetastoreTunnel metastoreTunnel = metaStore.getMetastoreTunnel();
     properties.put(ConfVars.METASTOREURIS.varname, uris);
-    if (metastoreTunnel != null) {
+    if (metaStore.getConnectionType() == TUNNELED) {
+      MetastoreTunnel metastoreTunnel = metaStore.getMetastoreTunnel();
       properties.put(WaggleDanceHiveConfVars.SSH_LOCALHOST.varname, metastoreTunnel.getLocalhost());
       properties.put(WaggleDanceHiveConfVars.SSH_PORT.varname, String.valueOf(metastoreTunnel.getPort()));
       properties.put(WaggleDanceHiveConfVars.SSH_ROUTE.varname, metastoreTunnel.getRoute());
       properties.put(WaggleDanceHiveConfVars.SSH_KNOWN_HOSTS.varname, metastoreTunnel.getKnownHosts());
       properties.put(WaggleDanceHiveConfVars.SSH_PRIVATE_KEYS.varname, metastoreTunnel.getPrivateKeys());
       properties.put(WaggleDanceHiveConfVars.SSH_SESSION_TIMEOUT.varname, String.valueOf(metastoreTunnel.getTimeout()));
-      properties.put(WaggleDanceHiveConfVars.SSH_STRICT_HOST_KEY_CHECKING.varname,
-          metastoreTunnel.getStrictHostKeyChecking());
+      properties
+          .put(WaggleDanceHiveConfVars.SSH_STRICT_HOST_KEY_CHECKING.varname,
+              metastoreTunnel.getStrictHostKeyChecking());
     }
     HiveConfFactory confFactory = new HiveConfFactory(Collections.<String> emptyList(), properties);
     return metaStoreClientFactory.newInstance(confFactory.newInstance(), "waggledance-" + name, 3);

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/client/ThriftMetastoreClient.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/client/ThriftMetastoreClient.java
@@ -156,7 +156,6 @@ class ThriftMetastoreClient implements Closeable {
           client = new ThriftHiveMetastore.Client(protocol);
           try {
             transport.open();
-            validateClientConnection();
             LOG
                 .info("Opened a connection to metastore '"
                     + store
@@ -196,13 +195,6 @@ class ThriftMetastoreClient implements Closeable {
     LOG.info("Connected to metastore.");
   }
 
-  private void validateClientConnection() throws TException {
-    // TODO PD disabling this for testing.
-    // if (client != null) {
-    // client.getStatus();
-    // }
-  }
-
   public void reconnect() {
     close();
     // Swap the first element of the metastoreUris[] with a random element from the rest
@@ -235,15 +227,7 @@ class ThriftMetastoreClient implements Closeable {
   }
 
   public boolean isOpen() {
-    if (transport != null && transport.isOpen()) {
-      try {
-        validateClientConnection();
-        return true;
-      } catch (TException e) {
-        return false;
-      }
-    }
-    return false;
+    return transport != null && transport.isOpen();
   }
 
   protected ThriftHiveMetastore.Iface getClient() {

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/client/ThriftMetastoreClient.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/client/ThriftMetastoreClient.java
@@ -131,12 +131,14 @@ class ThriftMetastoreClient implements Closeable {
               tokenStrForm = Utils.getTokenStrForm(tokenSig);
               if (tokenStrForm != null) {
                 // authenticate using delegation tokens via the "DIGEST" mechanism
-                transport = authBridge.createClientTransport(null, store.getHost(), "DIGEST", tokenStrForm, transport,
-                    MetaStoreUtils.getMetaStoreSaslProperties(conf));
+                transport = authBridge
+                    .createClientTransport(null, store.getHost(), "DIGEST", tokenStrForm, transport,
+                        MetaStoreUtils.getMetaStoreSaslProperties(conf));
               } else {
                 String principalConfig = conf.getVar(HiveConf.ConfVars.METASTORE_KERBEROS_PRINCIPAL);
-                transport = authBridge.createClientTransport(principalConfig, store.getHost(), "KERBEROS", null,
-                    transport, MetaStoreUtils.getMetaStoreSaslProperties(conf));
+                transport = authBridge
+                    .createClientTransport(principalConfig, store.getHost(), "KERBEROS", null, transport,
+                        MetaStoreUtils.getMetaStoreSaslProperties(conf));
               }
             } catch (IOException ioe) {
               LOG.error("Couldn't create client transport", ioe);
@@ -155,10 +157,11 @@ class ThriftMetastoreClient implements Closeable {
           try {
             transport.open();
             validateClientConnection();
-            LOG.info("Opened a connection to metastore '"
-                + store
-                + "', total current connections to all metastores: "
-                + CONN_COUNT.incrementAndGet());
+            LOG
+                .info("Opened a connection to metastore '"
+                    + store
+                    + "', total current connections to all metastores: "
+                    + CONN_COUNT.incrementAndGet());
 
             isConnected = true;
           } catch (TException e) {
@@ -194,9 +197,10 @@ class ThriftMetastoreClient implements Closeable {
   }
 
   private void validateClientConnection() throws TException {
-    if (client != null) {
-      client.getStatus();
-    }
+    // TODO PD disabling this for testing.
+    // if (client != null) {
+    // client.getStatus();
+    // }
   }
 
   public void reconnect() {

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/model/MetaStoreMappingFactoryImpl.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/model/MetaStoreMappingFactoryImpl.java
@@ -61,9 +61,11 @@ public class MetaStoreMappingFactoryImpl implements MetaStoreMappingFactory {
 
   @Override
   public MetaStoreMapping newInstance(AbstractMetaStore metaStore) {
-    LOG.info("Mapping databases with name '{}' to metastore: {}", metaStore.getName(), metaStore.getRemoteMetaStoreUris());
+    LOG
+        .info("Mapping databases with name '{}' to metastore: {}", metaStore.getName(),
+            metaStore.getRemoteMetaStoreUris());
     MetaStoreMapping mapping = new MetaStoreMappingImpl(prefixNameFor(metaStore), metaStore.getName(),
-        createClient(metaStore), accessControlHandlerFactory.newInstance(metaStore));
+        createClient(metaStore), accessControlHandlerFactory.newInstance(metaStore), metaStore.getConnectionType());
     return mapping;
   }
 
@@ -73,9 +75,9 @@ public class MetaStoreMappingFactoryImpl implements MetaStoreMappingFactory {
   }
 
   private CloseableThriftHiveMetastoreIface newUnreachableMetatstoreClient(AbstractMetaStore metaStore) {
-    return (CloseableThriftHiveMetastoreIface) Proxy.newProxyInstance(getClass().getClassLoader(),
-        new Class[] { CloseableThriftHiveMetastoreIface.class },
-        new UnreachableMetastoreClientInvocationHandler(metaStore.getName()));
+    return (CloseableThriftHiveMetastoreIface) Proxy
+        .newProxyInstance(getClass().getClassLoader(), new Class[] { CloseableThriftHiveMetastoreIface.class },
+            new UnreachableMetastoreClientInvocationHandler(metaStore.getName()));
   }
 
   /**

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/service/impl/SimpleFederationStatusService.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/service/impl/SimpleFederationStatusService.java
@@ -21,17 +21,17 @@ import org.springframework.stereotype.Service;
 import com.hotels.bdp.waggledance.api.federation.service.FederationStatusService;
 import com.hotels.bdp.waggledance.api.model.AbstractMetaStore;
 import com.hotels.bdp.waggledance.api.model.MetaStoreStatus;
-import com.hotels.bdp.waggledance.client.CloseableThriftHiveMetastoreIface;
-import com.hotels.bdp.waggledance.client.CloseableThriftHiveMetastoreIfaceClientFactory;
+import com.hotels.bdp.waggledance.mapping.model.MetaStoreMapping;
+import com.hotels.bdp.waggledance.mapping.service.MetaStoreMappingFactory;
 
 @Service
 public class SimpleFederationStatusService implements FederationStatusService {
 
-  private final CloseableThriftHiveMetastoreIfaceClientFactory metaStoreClientFactory;
+  private final MetaStoreMappingFactory metaStoreMappingFactory;
 
   @Autowired
-  public SimpleFederationStatusService(CloseableThriftHiveMetastoreIfaceClientFactory metaStoreClientFactory) {
-    this.metaStoreClientFactory = metaStoreClientFactory;
+  public SimpleFederationStatusService(MetaStoreMappingFactory metaStoreMappingFactory) {
+    this.metaStoreMappingFactory = metaStoreMappingFactory;
   }
 
   /**
@@ -47,8 +47,8 @@ public class SimpleFederationStatusService implements FederationStatusService {
    */
   @Override
   public MetaStoreStatus checkStatus(AbstractMetaStore abstractMetaStore) {
-    try (CloseableThriftHiveMetastoreIface client = metaStoreClientFactory.newInstance(abstractMetaStore)) {
-      if (!client.isOpen()) {
+    try (MetaStoreMapping mapping = metaStoreMappingFactory.newInstance(abstractMetaStore)) {
+      if (!mapping.isAvailable()) {
         return MetaStoreStatus.UNAVAILABLE;
       }
     } catch (Exception e) {

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/model/ASTQueryMappingTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/model/ASTQueryMappingTest.java
@@ -18,7 +18,7 @@ package com.hotels.bdp.waggledance.mapping.model;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-import static com.hotels.bdp.waggledance.api.model.ConnectionType.DIRECT_CONNECTION;
+import static com.hotels.bdp.waggledance.api.model.ConnectionType.DIRECT;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,7 +34,7 @@ public class ASTQueryMappingTest {
   @Test
   public void transformOutboundDatabaseName() {
     ASTQueryMapping queryMapping = ASTQueryMapping.INSTANCE;
-    MetaStoreMapping metaStoreMapping = new MetaStoreMappingImpl(PREFIX, "mapping", null, null, DIRECT_CONNECTION);
+    MetaStoreMapping metaStoreMapping = new MetaStoreMappingImpl(PREFIX, "mapping", null, null, DIRECT);
 
     String query = "SELECT *\n"
         + "FROM db1.table1 alias1 INNER JOIN db2.table2 alias2\n"
@@ -53,7 +53,7 @@ public class ASTQueryMappingTest {
   @Test
   public void transformOutboundDatabaseNameAliasWithBackTicks() {
     ASTQueryMapping queryMapping = ASTQueryMapping.INSTANCE;
-    MetaStoreMapping metaStoreMapping = new MetaStoreMappingImpl(PREFIX, "mapping", null, null, DIRECT_CONNECTION);
+    MetaStoreMapping metaStoreMapping = new MetaStoreMappingImpl(PREFIX, "mapping", null, null, DIRECT);
 
     String query = "";
     query += "SELECT col_id AS id ";
@@ -71,7 +71,7 @@ public class ASTQueryMappingTest {
   @Test(expected = WaggleDanceException.class)
   public void transformOutboundDatabaseNameParseException() {
     ASTQueryMapping queryMapping = ASTQueryMapping.INSTANCE;
-    MetaStoreMapping metaStoreMapping = new MetaStoreMappingImpl(PREFIX, "mapping", null, null, DIRECT_CONNECTION);
+    MetaStoreMapping metaStoreMapping = new MetaStoreMappingImpl(PREFIX, "mapping", null, null, DIRECT);
 
     String unparsableQuery = "SELCT *";
     queryMapping.transformOutboundDatabaseName(metaStoreMapping, unparsableQuery);

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/model/ASTQueryMappingTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/model/ASTQueryMappingTest.java
@@ -18,6 +18,8 @@ package com.hotels.bdp.waggledance.mapping.model;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
+import static com.hotels.bdp.waggledance.api.model.ConnectionType.DIRECT_CONNECTION;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -32,7 +34,7 @@ public class ASTQueryMappingTest {
   @Test
   public void transformOutboundDatabaseName() {
     ASTQueryMapping queryMapping = ASTQueryMapping.INSTANCE;
-    MetaStoreMapping metaStoreMapping = new MetaStoreMappingImpl(PREFIX, "mapping", null, null);
+    MetaStoreMapping metaStoreMapping = new MetaStoreMappingImpl(PREFIX, "mapping", null, null, DIRECT_CONNECTION);
 
     String query = "SELECT *\n"
         + "FROM db1.table1 alias1 INNER JOIN db2.table2 alias2\n"
@@ -51,7 +53,7 @@ public class ASTQueryMappingTest {
   @Test
   public void transformOutboundDatabaseNameAliasWithBackTicks() {
     ASTQueryMapping queryMapping = ASTQueryMapping.INSTANCE;
-    MetaStoreMapping metaStoreMapping = new MetaStoreMappingImpl(PREFIX, "mapping", null, null);
+    MetaStoreMapping metaStoreMapping = new MetaStoreMappingImpl(PREFIX, "mapping", null, null, DIRECT_CONNECTION);
 
     String query = "";
     query += "SELECT col_id AS id ";
@@ -69,7 +71,7 @@ public class ASTQueryMappingTest {
   @Test(expected = WaggleDanceException.class)
   public void transformOutboundDatabaseNameParseException() {
     ASTQueryMapping queryMapping = ASTQueryMapping.INSTANCE;
-    MetaStoreMapping metaStoreMapping = new MetaStoreMappingImpl(PREFIX, "mapping", null, null);
+    MetaStoreMapping metaStoreMapping = new MetaStoreMappingImpl(PREFIX, "mapping", null, null, DIRECT_CONNECTION);
 
     String unparsableQuery = "SELCT *";
     queryMapping.transformOutboundDatabaseName(metaStoreMapping, unparsableQuery);

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/model/MetaStoreMappingImplTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/model/MetaStoreMappingImplTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import static com.hotels.bdp.waggledance.api.model.ConnectionType.DIRECT_CONNECTION;
+import static com.hotels.bdp.waggledance.api.model.ConnectionType.DIRECT;
 import static com.hotels.bdp.waggledance.api.model.ConnectionType.TUNNELED;
 
 import java.io.IOException;
@@ -55,7 +55,7 @@ public class MetaStoreMappingImplTest {
 
   @Before
   public void init() {
-    metaStoreMapping = new MetaStoreMappingImpl(DATABASE_PREFIX, NAME, client, accessControlHandler, DIRECT_CONNECTION);
+    metaStoreMapping = new MetaStoreMappingImpl(DATABASE_PREFIX, NAME, client, accessControlHandler, DIRECT);
     tunneledMetaStoreMapping = new MetaStoreMappingImpl(DATABASE_PREFIX, NAME, client, accessControlHandler, TUNNELED);
 
   }

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/service/impl/SimpleFederationStatusServiceTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/service/impl/SimpleFederationStatusServiceTest.java
@@ -27,41 +27,41 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import com.hotels.bdp.waggledance.api.model.FederatedMetaStore;
 import com.hotels.bdp.waggledance.api.model.MetaStoreStatus;
-import com.hotels.bdp.waggledance.client.CloseableThriftHiveMetastoreIface;
-import com.hotels.bdp.waggledance.client.CloseableThriftHiveMetastoreIfaceClientFactory;
+import com.hotels.bdp.waggledance.mapping.model.MetaStoreMapping;
+import com.hotels.bdp.waggledance.mapping.service.MetaStoreMappingFactory;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SimpleFederationStatusServiceTest {
 
-  private @Mock CloseableThriftHiveMetastoreIfaceClientFactory metaStoreClientFactory;
-  private @Mock CloseableThriftHiveMetastoreIface client;
+  private @Mock MetaStoreMappingFactory metaStoreMappingFactory;
+  private @Mock MetaStoreMapping mapping;
   private SimpleFederationStatusService service;
 
   private final FederatedMetaStore metaStore = FederatedMetaStore.newFederatedInstance("remote", "uri");
 
   @Before
   public void setUp() {
-    service = new SimpleFederationStatusService(metaStoreClientFactory);
-    when(metaStoreClientFactory.newInstance(metaStore)).thenReturn(client);
+    service = new SimpleFederationStatusService(metaStoreMappingFactory);
+    when(metaStoreMappingFactory.newInstance(metaStore)).thenReturn(mapping);
   }
 
   @Test
   public void checkStatusAvailable() throws Exception {
-    when(client.isOpen()).thenReturn(true);
+    when(mapping.isAvailable()).thenReturn(true);
     MetaStoreStatus status = service.checkStatus(metaStore);
     assertThat(status, is(MetaStoreStatus.AVAILABLE));
   }
 
   @Test
   public void checkStatusUnavailable() throws Exception {
-    when(client.isOpen()).thenReturn(false);
+    when(mapping.isAvailable()).thenReturn(false);
     MetaStoreStatus status = service.checkStatus(metaStore);
     assertThat(status, is(MetaStoreStatus.UNAVAILABLE));
   }
 
   @Test
   public void checkStatusUnavailableViaException() throws Exception {
-    when(client.isOpen()).thenThrow(new RuntimeException("oh no metastore down!"));
+    when(mapping.isAvailable()).thenThrow(new RuntimeException("oh no metastore down!"));
     MetaStoreStatus status = service.checkStatus(metaStore);
     assertThat(status, is(MetaStoreStatus.UNAVAILABLE));
   }


### PR DESCRIPTION
trying to fix(or at least improve) on #115 

I've changed the code around a bit to allow for the getStatus call to be done only for tunneled connections. I haven't found any other way to figure out how a tunneled connection is working or not. Jsch has an ensureOpen, but that works even if the metatstore is not reachable, they only way to find it is doing some kind of call. We should not have to do this for the direct connections so we won't hit the extra call performance hit.


