### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,23 +3,20 @@ name: Bug report
 about: Create a report to help us improve
 
 ---
-<!-- before raising a bug report please consider the following:
- 1. If you want to ask a question don't raise a bug report - rather use the mailing list at https://groups.google.com/forum/#!forum/waggle-dance-user
- 2. Please ensure that the bug your are reporting is actually in Waggle Dance and not with Hive or whatever tools you are using to communicate with the metastore. 
-    Because Waggle Dance proxies the Hive metastore service it will just return any errors that the metastore itself throws and users sometimes mistakenly 
-    report these as Waggle Dance issues. The easiest way to check this is perform your operation against the underlying metastore directly 
-    (i.e. remove Waggle Dance from the equation by setting "hive.metastore.uris" to your metastore service endpoint and not Waggle Dance). If the issue still 
-    persists then it's not related to Waggle Dance and please don't report it here.  
-
+<!-- 
+ Before raising a bug report please consider the following:
+   1. If you want to ask a question don't raise a bug report - rather use the mailing list at https://groups.google.com/forum/#!forum/waggle-dance-user
+   2. Please ensure that the bug your are reporting is actually in Waggle Dance and not with Hive or whatever tools you are using to communicate with the metastore. 
+     Because Waggle Dance proxies the Hive metastore service it will just return any errors that the metastore itself throws and users sometimes mistakenly 
+     report these as Waggle Dance issues. The easiest way to check this is to perform your operation against the underlying metastore directly 
+     (i.e. remove Waggle Dance from the equation by setting "hive.metastore.uris" to your metastore service endpoint and not Waggle Dance). If the issue still 
+     persists then it's not related to Waggle Dance so please don't report it here.  
+-->
 **Describe the bug**
 A clear and concise description of what the bug is.
 
 **To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+Steps to reproduce the behaviour ideally including the configuration files you are using (feel free to rename any sensitive information like server and table names etc.)
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,6 +3,13 @@ name: Bug report
 about: Create a report to help us improve
 
 ---
+<!-- before raising a bug report please consider the following:
+ 1. If you want to ask a question don't raise a bug report - rather use the mailing list at https://groups.google.com/forum/#!forum/waggle-dance-user
+ 2. Please ensure that the bug your are reporting is actually in Waggle Dance and not with Hive or whatever tools you are using to communicate with the metastore. 
+    Because Waggle Dance proxies the Hive metastore service it will just return any errors that the metastore itself throws and users sometimes mistakenly 
+    report these as Waggle Dance issues. The easiest way to check this is perform your operation against the underlying metastore directly 
+    (i.e. remove Waggle Dance from the equation by setting "hive.metastore.uris" to your metastore service endpoint and not Waggle Dance). If the issue still 
+    persists then it's not related to Waggle Dance and please don't report it here.  
 
 **Describe the bug**
 A clear and concise description of what the bug is.
@@ -17,19 +24,13 @@ Steps to reproduce the behavior:
 **Expected behavior**
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+**Logs**
+Please add the log output from Waggle Dance when the error occurs, full stack traces are especially useful. It might also be worth looking in the Hive metastore 
+service log files to see if anything is output there and including that too.
 
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
-
-**Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+**Versions (please complete the following information):**
+ - Waggle Dance Version: 
+ - Hive Versions: for whatever Hive client libraries you are using as well as the versions of Hive in the metastore sevices that Waggle Dance is proxying
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -5,7 +5,7 @@ about: Suggest an idea for this project
 ---
 
 **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+A clear and concise description of what the problem is. For example - I'm always frustrated when [...]
 
 **Describe the solution you'd like**
 A clear and concise description of what you want to happen.


### PR DESCRIPTION
Modified versions of standard GitHub issue templates which should help reduce the number of incorrect issue requests we've been receiving and also contain pointers so users can provide more useful information upfront.