### PR TITLE
issue-110: added compatibility proxy layer 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 ## [TBD] - TBD
 ### Changed
 * Minimum supported Java version is now 8 (was 7). See [#108](https://github.com/HotelsDotCom/waggle-dance/issues/108).
+### Fixed
+* Added workaround when federating to a Hive 1.x Metastore. See [#110](https://github.com/HotelsDotCom/waggle-dance/issues/110).
 
 ## [2.4.2] - 2018-08-21
 ### Changed
-* Removed performance hit we get from checking if a connection is alive for non-tunnelled connections. See [#115](https://github.com/HotelsDotCom/waggle-dance/issues/115).
+* Removed performance hit we get from checking if a connection is alive for non-tunneled connections. See [#115](https://github.com/HotelsDotCom/waggle-dance/issues/115).
 * Removed System.exit calls from the service instead it will exit with an exception if the Spring Boot exit code is not 0.
 
 ## [2.4.1] - 2018-08-10

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/client/DefaultMetaStoreClientFactory.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/client/DefaultMetaStoreClientFactory.java
@@ -27,6 +27,8 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import com.hotels.bdp.waggledance.client.compatibility.HiveCompatibleThriftHiveMetastoreIfaceFactory;
+
 public class DefaultMetaStoreClientFactory implements MetaStoreClientFactory {
 
   static final Class<?>[] INTERFACES = new Class<?>[] { CloseableThriftHiveMetastoreIface.class };
@@ -38,7 +40,10 @@ public class DefaultMetaStoreClientFactory implements MetaStoreClientFactory {
     private final String name;
     private final int maxRetries;
 
-    private ReconnectingMetastoreClientInvocationHandler(String name, int maxRetries, ThriftMetastoreClientManager base) {
+    private ReconnectingMetastoreClientInvocationHandler(
+        String name,
+        int maxRetries,
+        ThriftMetastoreClientManager base) {
       this.name = name;
       this.maxRetries = maxRetries;
       this.base = base;
@@ -114,11 +119,15 @@ public class DefaultMetaStoreClientFactory implements MetaStoreClientFactory {
    */
   @Override
   public CloseableThriftHiveMetastoreIface newInstance(HiveConf hiveConf, String name, int reconnectionRetries) {
-    return newInstance(name, reconnectionRetries, new ThriftMetastoreClientManager(hiveConf));
+    return newInstance(name, reconnectionRetries,
+        new ThriftMetastoreClientManager(hiveConf, new HiveCompatibleThriftHiveMetastoreIfaceFactory()));
   }
 
   @VisibleForTesting
-  CloseableThriftHiveMetastoreIface newInstance(String name, int reconnectionRetries, ThriftMetastoreClientManager base) {
+  CloseableThriftHiveMetastoreIface newInstance(
+      String name,
+      int reconnectionRetries,
+      ThriftMetastoreClientManager base) {
     ReconnectingMetastoreClientInvocationHandler reconnectingHandler = new ReconnectingMetastoreClientInvocationHandler(
         name, reconnectionRetries, base);
     return (CloseableThriftHiveMetastoreIface) Proxy

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/client/compatibility/HiveCompatibleThriftHiveMetastoreIfaceFactory.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/client/compatibility/HiveCompatibleThriftHiveMetastoreIfaceFactory.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (C) 2016-2018 Expedia Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hotels.bdp.waggledance.client.compatibility;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+import org.apache.hadoop.hive.metastore.api.ThriftHiveMetastore;
+import org.apache.thrift.TApplicationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.hotels.bdp.waggledance.client.CloseableThriftHiveMetastoreIface;
+
+public class HiveCompatibleThriftHiveMetastoreIfaceFactory {
+
+  private static final Logger log = LoggerFactory.getLogger(HiveCompatibleThriftHiveMetastoreIfaceFactory.class);
+
+  class ThriftMetaStoreClientInvocationHandler implements InvocationHandler {
+
+    private final ThriftHiveMetastore.Client delegate;
+    private final HiveThriftMetaStoreIfaceCompatibility compatibility;
+
+    ThriftMetaStoreClientInvocationHandler(
+        ThriftHiveMetastore.Client delegate,
+        HiveThriftMetaStoreIfaceCompatibility compatibility) {
+      this.delegate = delegate;
+      this.compatibility = compatibility;
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+      try {
+        return method.invoke(delegate, args);
+      } catch (InvocationTargetException e) {
+        try {
+          log.info("Couldn't invoke method {}", method.toGenericString());
+          if (compatibility != null && e.getCause().getClass().isAssignableFrom(TApplicationException.class)) {
+            log.info("Attempting to invoke with {}", compatibility.getClass().getName());
+            return invokeCompatibility(method, args);
+          }
+        } catch (Throwable t) {
+          log
+              .warn("Unable to run compatibility for metastore client method {}. Will rethrow original exception: ",
+                  method.getName(), t);
+        }
+        throw e.getCause();
+      }
+    }
+
+    private Object invokeCompatibility(Method method, Object[] args) throws Throwable {
+      Class<?>[] argTypes = getTypes(args);
+      Method compatibilityMethod = compatibility.getClass().getMethod(method.getName(), argTypes);
+      return compatibilityMethod.invoke(compatibility, args);
+    }
+
+    private Class<?>[] getTypes(Object[] args) {
+      Class<?>[] argTypes = new Class<?>[args.length];
+      for (int i = 0; i < args.length; ++i) {
+        argTypes[i] = args[i].getClass();
+      }
+      return argTypes;
+    }
+
+  }
+
+  public CloseableThriftHiveMetastoreIface newInstance(ThriftHiveMetastore.Client delegate) {
+    HiveThriftMetaStoreIfaceCompatibility compatibility = new HiveThriftMetaStoreIfaceCompatibility1xx(delegate);
+    return newInstance(delegate, compatibility);
+  }
+
+  CloseableThriftHiveMetastoreIface newInstance(
+      ThriftHiveMetastore.Client delegate,
+      HiveThriftMetaStoreIfaceCompatibility compatibility) {
+    ClassLoader classLoader = CloseableThriftHiveMetastoreIface.class.getClassLoader();
+    Class<?>[] interfaces = new Class<?>[] { CloseableThriftHiveMetastoreIface.class };
+    ThriftMetaStoreClientInvocationHandler handler = new ThriftMetaStoreClientInvocationHandler(delegate,
+        compatibility);
+    return (CloseableThriftHiveMetastoreIface) Proxy.newProxyInstance(classLoader, interfaces, handler);
+  }
+
+}

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/client/compatibility/HiveCompatibleThriftHiveMetastoreIfaceFactory.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/client/compatibility/HiveCompatibleThriftHiveMetastoreIfaceFactory.java
@@ -50,7 +50,7 @@ public class HiveCompatibleThriftHiveMetastoreIfaceFactory {
       } catch (InvocationTargetException e) {
         try {
           log.info("Couldn't invoke method {}", method.toGenericString());
-          if (compatibility != null && e.getCause().getClass().isAssignableFrom(TApplicationException.class)) {
+          if (e.getCause().getClass().isAssignableFrom(TApplicationException.class)) {
             log.info("Attempting to invoke with {}", compatibility.getClass().getName());
             return invokeCompatibility(method, args);
           }
@@ -70,6 +70,9 @@ public class HiveCompatibleThriftHiveMetastoreIfaceFactory {
     }
 
     private Class<?>[] getTypes(Object[] args) {
+      if (args == null) {
+        return (Class<?>[]) args;
+      }
       Class<?>[] argTypes = new Class<?>[args.length];
       for (int i = 0; i < args.length; ++i) {
         argTypes[i] = args[i].getClass();
@@ -84,7 +87,7 @@ public class HiveCompatibleThriftHiveMetastoreIfaceFactory {
     return newInstance(delegate, compatibility);
   }
 
-  CloseableThriftHiveMetastoreIface newInstance(
+  private CloseableThriftHiveMetastoreIface newInstance(
       ThriftHiveMetastore.Client delegate,
       HiveThriftMetaStoreIfaceCompatibility compatibility) {
     ClassLoader classLoader = CloseableThriftHiveMetastoreIface.class.getClassLoader();

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/client/compatibility/HiveThriftMetaStoreIfaceCompatibility.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/client/compatibility/HiveThriftMetaStoreIfaceCompatibility.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2016-2018 Expedia Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hotels.bdp.waggledance.client.compatibility;
+
+import org.apache.hadoop.hive.metastore.api.GetTableRequest;
+import org.apache.hadoop.hive.metastore.api.GetTableResult;
+import org.apache.hadoop.hive.metastore.api.GetTablesRequest;
+import org.apache.hadoop.hive.metastore.api.GetTablesResult;
+import org.apache.hadoop.hive.metastore.api.InvalidOperationException;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.apache.hadoop.hive.metastore.api.UnknownDBException;
+import org.apache.thrift.TException;
+
+/**
+ * This interface contains methods that are missing from Hive 1.x.x but added in later version of Hive
+ */
+public interface HiveThriftMetaStoreIfaceCompatibility {
+
+  /*
+   * https://hive.apache.org/javadocs/r2.3.3/api/org/apache/hadoop/hive/metastore/api/ThriftHiveMetastore.Client.html#
+   * get_table_req(org.apache.hadoop.hive.metastore.api.GetTableRequest). Missing in hive 1.x.x
+   */
+  GetTableResult get_table_req(GetTableRequest req) throws MetaException, NoSuchObjectException, TException;
+
+  /*
+   * https://hive.apache.org/javadocs/r2.3.3/api/org/apache/hadoop/hive/metastore/api/ThriftHiveMetastore.Client.html#
+   * get_table_objects_by_name_req(org.apache.hadoop.hive.metastore.api.GetTablesRequest). Missing in hive 1.x.x
+   */
+  GetTablesResult get_table_objects_by_name_req(GetTablesRequest req)
+    throws MetaException, InvalidOperationException, UnknownDBException, TException;
+}

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/client/compatibility/HiveThriftMetaStoreIfaceCompatibility1xx.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/client/compatibility/HiveThriftMetaStoreIfaceCompatibility1xx.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (C) 2016-2018 Expedia Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hotels.bdp.waggledance.client.compatibility;
+
+import java.util.List;
+
+import org.apache.hadoop.hive.metastore.api.GetTableRequest;
+import org.apache.hadoop.hive.metastore.api.GetTableResult;
+import org.apache.hadoop.hive.metastore.api.GetTablesRequest;
+import org.apache.hadoop.hive.metastore.api.GetTablesResult;
+import org.apache.hadoop.hive.metastore.api.InvalidOperationException;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.metastore.api.ThriftHiveMetastore;
+import org.apache.hadoop.hive.metastore.api.UnknownDBException;
+import org.apache.thrift.TException;
+
+public class HiveThriftMetaStoreIfaceCompatibility1xx implements HiveThriftMetaStoreIfaceCompatibility {
+
+  private final ThriftHiveMetastore.Client client;
+
+  public HiveThriftMetaStoreIfaceCompatibility1xx(ThriftHiveMetastore.Client client) {
+    this.client = client;
+  }
+
+  /*
+   * (non-Javadoc)
+   * @see
+   * com.hotels.bdp.waggledance.client.compatibility.HiveThriftMetaStoreIfaceCompatibility#get_table_req(org.apache.
+   * hadoop.hive.metastore.api.GetTableRequest) This method is missing in Hive 1.x.x, this implementation is an attempt
+   * to implement it using the Hive 1.x.x methods only.
+   */
+  @Override
+  public GetTableResult get_table_req(GetTableRequest req) throws MetaException, NoSuchObjectException, TException {
+    Table table = client.get_table(req.getDbName(), req.getTblName());
+    return new GetTableResult(table);
+  }
+
+  /*
+   * (non-Javadoc)
+   * @see
+   * com.hotels.bdp.waggledance.client.compatibility.HiveThriftMetaStoreIfaceCompatibility#get_table_objects_by_name_req
+   * (org.apache. hadoop.hive.metastore.api.GetTablesRequest) This method is missing in Hive 1.x.x, this implementation
+   * is an attempt to implement it using the Hive 1.x.x methods only.
+   */
+  @Override
+  public GetTablesResult get_table_objects_by_name_req(GetTablesRequest req)
+    throws MetaException, InvalidOperationException, UnknownDBException, TException {
+    List<Table> get_table_objects_by_name = client.get_table_objects_by_name(req.getDbName(), req.getTblNames());
+    return new GetTablesResult(get_table_objects_by_name);
+  }
+}

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/client/compatibility/HiveThriftMetaStoreIfaceCompatibility1xx.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/client/compatibility/HiveThriftMetaStoreIfaceCompatibility1xx.java
@@ -60,7 +60,7 @@ public class HiveThriftMetaStoreIfaceCompatibility1xx implements HiveThriftMetaS
   @Override
   public GetTablesResult get_table_objects_by_name_req(GetTablesRequest req)
     throws MetaException, InvalidOperationException, UnknownDBException, TException {
-    List<Table> get_table_objects_by_name = client.get_table_objects_by_name(req.getDbName(), req.getTblNames());
-    return new GetTablesResult(get_table_objects_by_name);
+    List<Table> tables = client.get_table_objects_by_name(req.getDbName(), req.getTblNames());
+    return new GetTablesResult(tables);
   }
 }

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/client/ThriftMetastoreClientManagerIntegrationTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/client/ThriftMetastoreClientManagerIntegrationTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import com.hotels.bdp.waggledance.client.compatibility.HiveCompatibleThriftHiveMetastoreIfaceFactory;
 import com.hotels.beeju.ThriftHiveMetaStoreJUnitRule;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -36,13 +37,14 @@ public class ThriftMetastoreClientManagerIntegrationTest {
   @Rule
   public ThriftHiveMetaStoreJUnitRule hive = new ThriftHiveMetaStoreJUnitRule("dbname");
 
+  private final HiveCompatibleThriftHiveMetastoreIfaceFactory hiveCompatibleThriftHiveMetastoreIfaceFactory = new HiveCompatibleThriftHiveMetastoreIfaceFactory();
   private final HiveConf hiveConf = new HiveConf();
   private ThriftMetastoreClientManager manager;
 
   @Before
   public void init() throws Exception {
     hiveConf.setVar(ConfVars.METASTOREURIS, hive.getThriftConnectionUri());
-    manager = new ThriftMetastoreClientManager(hiveConf);
+    manager = new ThriftMetastoreClientManager(hiveConf, hiveCompatibleThriftHiveMetastoreIfaceFactory);
   }
 
   @Test
@@ -64,7 +66,7 @@ public class ThriftMetastoreClientManagerIntegrationTest {
   @Test
   public void openWithDummyConnectionThrowsRuntimeWithOriginalExceptionInMessage() throws Exception {
     hiveConf.setVar(ConfVars.METASTOREURIS, "thrift://localhost:123");
-    manager = new ThriftMetastoreClientManager(hiveConf);
+    manager = new ThriftMetastoreClientManager(hiveConf, hiveCompatibleThriftHiveMetastoreIfaceFactory);
 
     try {
       manager.open();

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/client/ThriftMetastoreClientManagerTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/client/ThriftMetastoreClientManagerTest.java
@@ -30,10 +30,13 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.hotels.bdp.waggledance.client.compatibility.HiveCompatibleThriftHiveMetastoreIfaceFactory;
+
 @RunWith(MockitoJUnitRunner.class)
 public class ThriftMetastoreClientManagerTest {
 
   private @Mock TSocket transport;
+  private @Mock HiveCompatibleThriftHiveMetastoreIfaceFactory hiveCompatibleThriftHiveMetastoreIfaceFactory;
 
   private final HiveConf hiveConf = new HiveConf();
   private ThriftMetastoreClientManager client;
@@ -41,7 +44,7 @@ public class ThriftMetastoreClientManagerTest {
   @Before
   public void init() throws Exception {
     hiveConf.setVar(ConfVars.METASTOREURIS, "thrift://localhost:123");
-    client = new ThriftMetastoreClientManager(hiveConf);
+    client = new ThriftMetastoreClientManager(hiveConf, hiveCompatibleThriftHiveMetastoreIfaceFactory);
     ReflectionTestUtils.setField(client, "transport", transport);
     ReflectionTestUtils.setField(client, "isConnected", true);
   }
@@ -49,25 +52,25 @@ public class ThriftMetastoreClientManagerTest {
   @Test(expected = RuntimeException.class)
   public void constructorEmptyURI() {
     hiveConf.setVar(ConfVars.METASTOREURIS, "");
-    client = new ThriftMetastoreClientManager(hiveConf);
+    client = new ThriftMetastoreClientManager(hiveConf, hiveCompatibleThriftHiveMetastoreIfaceFactory);
   }
 
   @Test(expected = RuntimeException.class)
   public void constructorNullURI() {
     hiveConf.setVar(ConfVars.METASTOREURIS, null);
-    client = new ThriftMetastoreClientManager(hiveConf);
+    client = new ThriftMetastoreClientManager(hiveConf, hiveCompatibleThriftHiveMetastoreIfaceFactory);
   }
 
   @Test(expected = RuntimeException.class)
   public void constructorNullURISchema() {
     hiveConf.setVar(ConfVars.METASTOREURIS, "123");
-    client = new ThriftMetastoreClientManager(hiveConf);
+    client = new ThriftMetastoreClientManager(hiveConf, hiveCompatibleThriftHiveMetastoreIfaceFactory);
   }
 
   @Test(expected = RuntimeException.class)
   public void constructorInvalidURI() {
     hiveConf.setVar(ConfVars.METASTOREURIS, "://localhost:123");
-    client = new ThriftMetastoreClientManager(hiveConf);
+    client = new ThriftMetastoreClientManager(hiveConf, hiveCompatibleThriftHiveMetastoreIfaceFactory);
   }
 
   @Test

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/client/compatibility/HiveCompatibleThriftHiveMetastoreIfaceFactoryTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/client/compatibility/HiveCompatibleThriftHiveMetastoreIfaceFactoryTest.java
@@ -1,0 +1,95 @@
+package com.hotels.bdp.waggledance.client.compatibility;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.hadoop.hive.metastore.api.GetTableRequest;
+import org.apache.hadoop.hive.metastore.api.GetTableResult;
+import org.apache.hadoop.hive.metastore.api.GetTablesRequest;
+import org.apache.hadoop.hive.metastore.api.GetTablesResult;
+import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.metastore.api.ThriftHiveMetastore.Client;
+import org.apache.thrift.TApplicationException;
+import org.apache.thrift.TException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import com.google.common.collect.Lists;
+
+import com.hotels.bdp.waggledance.client.CloseableThriftHiveMetastoreIface;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HiveCompatibleThriftHiveMetastoreIfaceFactoryTest {
+
+  private final HiveCompatibleThriftHiveMetastoreIfaceFactory factory = new HiveCompatibleThriftHiveMetastoreIfaceFactory();
+
+  private static final String DB_NAME = "db";
+  private static final String TABLE_NAME = "table";
+  private @Mock Client delegate;
+  private final Table table = new Table(DB_NAME, TABLE_NAME, "", 0, 0, 0, null, null, null, "", "", "");
+
+  @Test
+  public void get_table_req() throws Exception {
+    CloseableThriftHiveMetastoreIface thriftHiveMetastoreIface = factory.newInstance(delegate);
+    GetTableRequest tableRequest = new GetTableRequest(DB_NAME, TABLE_NAME);
+    when(delegate.get_table_req(tableRequest)).thenThrow(new TApplicationException("Error"));
+    when(delegate.get_table(DB_NAME, TABLE_NAME)).thenReturn(table);
+    GetTableResult tableResult = thriftHiveMetastoreIface.get_table_req(tableRequest);
+    assertThat(tableResult, is(new GetTableResult(table)));
+  }
+
+  @Test
+  public void get_table_objects_by_name_req() throws Exception {
+    CloseableThriftHiveMetastoreIface thriftHiveMetastoreIface = factory.newInstance(delegate);
+    GetTablesRequest tablesRequest = new GetTablesRequest(DB_NAME);
+    tablesRequest.addToTblNames(TABLE_NAME);
+    when(delegate.get_table_objects_by_name_req(tablesRequest)).thenThrow(new TApplicationException("Error"));
+    when(delegate.get_table_objects_by_name(DB_NAME, Lists.newArrayList(TABLE_NAME)))
+        .thenReturn(Lists.newArrayList(table));
+    GetTablesResult tablesResult = thriftHiveMetastoreIface.get_table_objects_by_name_req(tablesRequest);
+    assertThat(tablesResult, is(new GetTablesResult(Lists.newArrayList(table))));
+  }
+
+  @Test
+  public void normalGetTableCallWorks() throws Exception {
+    CloseableThriftHiveMetastoreIface thriftHiveMetastoreIface = factory.newInstance(delegate);
+    when(delegate.get_table(DB_NAME, TABLE_NAME)).thenReturn(table);
+    Table tableResult = thriftHiveMetastoreIface.get_table(DB_NAME, TABLE_NAME);
+    assertThat(tableResult, is(table));
+  }
+
+  @Test
+  public void underlyingExceptionIsThrownWhenCompatibilityFails() throws Exception {
+    CloseableThriftHiveMetastoreIface thriftHiveMetastoreIface = factory.newInstance(delegate);
+    when(delegate.get_all_databases()).thenThrow(new TApplicationException("CAUSE"));
+    try {
+      thriftHiveMetastoreIface.get_all_databases();
+      fail("exception should have been thrown");
+    } catch (TApplicationException e) {
+      assertThat(e.getMessage(), is("CAUSE"));
+    }
+  }
+
+  @Test
+  public void nonTApplicationExceptionsAreThrown() throws Exception {
+    CloseableThriftHiveMetastoreIface thriftHiveMetastoreIface = factory.newInstance(delegate);
+    GetTableRequest tableRequest = new GetTableRequest(DB_NAME, TABLE_NAME);
+    when(delegate.get_table_req(tableRequest))
+        .thenThrow(new NoSuchObjectException("Normal Error nothing to do with compatibility"));
+    try {
+      thriftHiveMetastoreIface.get_table_req(tableRequest);
+      fail("exception should have been thrown");
+    } catch (TException e) {
+      assertThat(e.getMessage(), is("Normal Error nothing to do with compatibility"));
+      verify(delegate, never()).get_table(DB_NAME, TABLE_NAME);
+    }
+  }
+
+}


### PR DESCRIPTION
fixes #110 
Handling the case where a federated metastore is an old api (1.x.x) and the client tries to call a new 
api (2.x.x) method. 

I've only "implemented" this fix for two method calls. I've tested that it solves the issue (using emr-4.9.5, hive-1.0.0). I could do `desc` and `show create table` commands successfully.

If we look at our https://github.com/HotelsDotCom/waggle-dance/blob/311a6b3769ef0281458aeadeb6cf43e6576408a7/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/server/FederatedHMSHandler.java#L1567 class you'll see there are more methods added. (even more if you go back to hive 2.1.x). 
I am not sure what approach we should take here, as the preferred solution is to update an old metastore (if possible). There are some calls that have been added that we just cannot support/implement.  

Shall I make our compatibility list more exhaustive or shall we go with this for now?