### PR TITLE
Fix metastore tunnel config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [3.1.1] - 2018-10-30
+### Fixed
+* Issue where setting strict-host-key-checking for metastore-tunnel causes an error. See [#145](https://github.com/HotelsDotCom/waggle-dance/issues/145).
+
 ## [3.1.0] - 2018-10-25
 ### Changed
 * Refactored general metastore tunnelling code to leverage hcommon-hive-metastore libraries. See [#103](https://github.com/HotelsDotCom/waggle-dance/issues/103).

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <beeju.version>1.2.1</beeju.version>
     <guava.version>23.0</guava.version>
     <guice.version>4.0</guice.version>
-    <hcommon-hive-metastore.version>1.2.2</hcommon-hive-metastore.version>
+    <hcommon-hive-metastore.version>1.2.3-SNAPSHOT</hcommon-hive-metastore.version>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <beeju.version>1.2.1</beeju.version>
     <guava.version>23.0</guava.version>
     <guice.version>4.0</guice.version>
-    <hcommon-hive-metastore.version>1.2.3-SNAPSHOT</hcommon-hive-metastore.version>
+    <hcommon-hive-metastore.version>1.2.3</hcommon-hive-metastore.version>
   </properties>
 
   <dependencyManagement>

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/client/tunnelling/TunnelableFactorySupplier.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/client/tunnelling/TunnelableFactorySupplier.java
@@ -44,7 +44,7 @@ public class TunnelableFactorySupplier {
         .withKnownHosts(metastoreTunnel.getKnownHosts())
         .withLocalhost(metastoreTunnel.getLocalhost())
         .withPrivateKeys(metastoreTunnel.getPrivateKeys())
-        .withStrictHostKeyChecking(metastoreTunnel.isStrictHostKeyChecking())
+        .withStrictHostKeyChecking(metastoreTunnel.getIsStrictHostKeyChecking())
         .build();
   }
 }

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/client/tunnelling/TunnelableFactorySupplier.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/client/tunnelling/TunnelableFactorySupplier.java
@@ -44,7 +44,7 @@ public class TunnelableFactorySupplier {
         .withKnownHosts(metastoreTunnel.getKnownHosts())
         .withLocalhost(metastoreTunnel.getLocalhost())
         .withPrivateKeys(metastoreTunnel.getPrivateKeys())
-        .withStrictHostKeyChecking(metastoreTunnel.getIsStrictHostKeyChecking())
+        .withStrictHostKeyChecking(metastoreTunnel.isStrictHostKeyCheckingEnabled())
         .build();
   }
 }


### PR DESCRIPTION
Fixes https://github.com/HotelsDotCom/waggle-dance/issues/145

Depends on: https://github.com/HotelsDotCom/hcommon-hive-metastore/pull/10

Will update with the released version of hcommon-hive-metastore before merging.