### PR TITLE
Add validation error when mapped-databases does not have elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## TBD
 ### Fixed
 * Support for regex `mapped-databases` for MANUAL database resolution. See [#147](https://github.com/HotelsDotCom/waggle-dance/issues/147).
+* Avoid NPE when no elements are provided for `mapped-databases` in the configuration. See [#131](https://github.com/HotelsDotCom/waggle-dance/issues/131).
 
 ## [3.1.2] - 2019-01-11
 ### Changed

--- a/waggle-dance-api/src/main/java/com/hotels/bdp/waggledance/api/model/FederatedMetaStore.java
+++ b/waggle-dance-api/src/main/java/com/hotels/bdp/waggledance/api/model/FederatedMetaStore.java
@@ -20,6 +20,9 @@ import java.util.List;
 
 import org.hibernate.validator.constraints.NotBlank;
 
+import com.hotels.bdp.waggledance.api.ValidationError;
+import com.hotels.bdp.waggledance.api.WaggleDanceException;
+
 public class FederatedMetaStore extends AbstractMetaStore {
 
   private List<String> mappedDatabases = Collections.emptyList();
@@ -67,6 +70,10 @@ public class FederatedMetaStore extends AbstractMetaStore {
   }
 
   public void setMappedDatabases(List<String> mappedDatabases) {
+    if (mappedDatabases == null) {
+      ValidationError validationError = ValidationError.builder().error("mapped-databases should not be null").build();
+      throw new WaggleDanceException(validationError.getErrorMessage());
+    }
     this.mappedDatabases = mappedDatabases;
   }
 }

--- a/waggle-dance-api/src/main/java/com/hotels/bdp/waggledance/api/model/FederatedMetaStore.java
+++ b/waggle-dance-api/src/main/java/com/hotels/bdp/waggledance/api/model/FederatedMetaStore.java
@@ -18,14 +18,13 @@ package com.hotels.bdp.waggledance.api.model;
 import java.util.Collections;
 import java.util.List;
 
-import org.hibernate.validator.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 
-import com.hotels.bdp.waggledance.api.ValidationError;
-import com.hotels.bdp.waggledance.api.WaggleDanceException;
+import org.hibernate.validator.constraints.NotBlank;
 
 public class FederatedMetaStore extends AbstractMetaStore {
 
-  private List<String> mappedDatabases = Collections.emptyList();
+  private @NotNull List<String> mappedDatabases = Collections.emptyList();
 
   public FederatedMetaStore() {}
 
@@ -70,10 +69,6 @@ public class FederatedMetaStore extends AbstractMetaStore {
   }
 
   public void setMappedDatabases(List<String> mappedDatabases) {
-    if (mappedDatabases == null) {
-      ValidationError validationError = ValidationError.builder().error("mapped-databases should not be null").build();
-      throw new WaggleDanceException(validationError.getErrorMessage());
-    }
     this.mappedDatabases = mappedDatabases;
   }
 }

--- a/waggle-dance-api/src/test/java/com/hotels/bdp/waggledance/api/model/FederatedMetaStoreTest.java
+++ b/waggle-dance-api/src/test/java/com/hotels/bdp/waggledance/api/model/FederatedMetaStoreTest.java
@@ -29,8 +29,6 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import com.hotels.bdp.waggledance.api.WaggleDanceException;
-
 public class FederatedMetaStoreTest extends AbstractMetaStoreTest<FederatedMetaStore> {
 
   public FederatedMetaStoreTest() {
@@ -91,9 +89,11 @@ public class FederatedMetaStoreTest extends AbstractMetaStoreTest<FederatedMetaS
     assertThat(metaStore.getMappedDatabases(), is(mappedDatabases));
   }
 
-  @Test(expected = WaggleDanceException.class)
+  @Test
   public void nullMappedDatabases() {
     metaStore.setMappedDatabases(null);
+    Set<ConstraintViolation<FederatedMetaStore>> violations = validator.validate(metaStore);
+    assertThat(violations.size(), is(1));
   }
 
   @Test

--- a/waggle-dance-api/src/test/java/com/hotels/bdp/waggledance/api/model/FederatedMetaStoreTest.java
+++ b/waggle-dance-api/src/test/java/com/hotels/bdp/waggledance/api/model/FederatedMetaStoreTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2018 Expedia Inc.
+ * Copyright (C) 2016-2019 Expedia Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,8 @@ import org.junit.Test;
 
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.hotels.bdp.waggledance.api.WaggleDanceException;
 
 public class FederatedMetaStoreTest extends AbstractMetaStoreTest<FederatedMetaStore> {
 
@@ -87,6 +89,11 @@ public class FederatedMetaStoreTest extends AbstractMetaStoreTest<FederatedMetaS
     mappedDatabases.add("database");
     metaStore.setMappedDatabases(mappedDatabases);
     assertThat(metaStore.getMappedDatabases(), is(mappedDatabases));
+  }
+
+  @Test(expected = WaggleDanceException.class)
+  public void nullMappedDatabases() {
+    metaStore.setMappedDatabases(null);
   }
 
   @Test


### PR DESCRIPTION
Fixes #131 

Example:

Using the following configuration 
```yaml
primary-meta-store:
  access-control-type: READ_ONLY
  name: primary
  remote-meta-store-uris: thrift://...:9083

federated-meta-stores:
- access-control-type: READ_ONLY
  database-prefix: secondary_
  mapped-databases:
  name: remote
  remote-meta-store-uris: thrift://...:48869
```

We now get the following output (in MANUAL and PREFIXED mode):
```
2019-02-13 15:36:42.336 ERROR 24794 --- [           main] c.h.b.w.WaggleDance                      : Validation errors:
2019-02-13 15:36:42.336 ERROR 24794 --- [           main] c.h.b.w.WaggleDance                      : ConstraintViolationImpl{interpolatedMessage='must not be null', propertyPath=federatedMetaStores[0].mappedDatabases, rootBeanClass=class com.hotels.bdp.waggledance.api.model.Federations, messageTemplate='{javax.validation.constraints.NotNull.message}'}
```