### PR TITLE
Upgrade Hive to 2.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * Upgraded version of `hive.version` to `2.3.7` (was `2.3.3`). Allows Waggle Dance to be used on JDK>=9.
 
 ### Added
-* Implemented `get_partition_values()` method in `FederatedHMSHandler` due to hive version change.
+* Implemented `get_partition_values()` method in `FederatedHMSHandler` due to Hive version change.
 
 ## [3.6.0] - 2020-03-04
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [3.6.1] - TBD
+## [3.7.0] - TBD
 ### Changed
 * Upgraded version of `hive.version` to `2.3.7` (was `2.3.3`). Allows Waggle Dance to be used on JDK>=9.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [3.6.1] - TBD
+### Changed
+* Upgraded version of `hive.version` to `2.3.7` (was `2.3.3`). Allows Waggle Dance to be used on JDK>=9.
+
+### Added
+* Implemented `get_partition_values()` method in `FederatedHMSHandler` due to hive version change.
+
 ## [3.6.0] - 2020-03-04
 ### Changed
 * Updated `hotels-oss-parent` to 5.0.0 (was 4.0.1).

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
     <spring-boot.version>2.0.4.RELEASE</spring-boot.version>
     <hadoop.version>2.7.2</hadoop.version>
-    <hive.version>2.3.3</hive.version>
+    <hive.version>2.3.7</hive.version>
     <dropwizard.metrics.version>3.1.5</dropwizard.metrics.version>
     <aspectj-maven-plugin.version>1.9</aspectj-maven-plugin.version>
     <aspectj.version>1.8.9</aspectj.version>

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/model/DatabaseMapping.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/model/DatabaseMapping.java
@@ -42,6 +42,8 @@ import org.apache.hadoop.hive.metastore.api.Index;
 import org.apache.hadoop.hive.metastore.api.LockRequest;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.PartitionSpec;
+import org.apache.hadoop.hive.metastore.api.PartitionValuesRequest;
+import org.apache.hadoop.hive.metastore.api.PartitionValuesResponse;
 import org.apache.hadoop.hive.metastore.api.PartitionsByExprRequest;
 import org.apache.hadoop.hive.metastore.api.PartitionsByExprResult;
 import org.apache.hadoop.hive.metastore.api.PartitionsStatsRequest;
@@ -146,6 +148,8 @@ public interface DatabaseMapping extends MetaStoreMapping {
   GetTablesRequest transformInboundGetTablesRequest(GetTablesRequest req);
 
   GetTablesResult transformOutboundGetTablesResult(GetTablesResult result);
+
+  PartitionValuesRequest transformInboundPartitionValuesRequest(PartitionValuesRequest req);
 
   @Override
   long getLatency();

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/model/DatabaseMapping.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/model/DatabaseMapping.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,6 @@ import org.apache.hadoop.hive.metastore.api.LockRequest;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.PartitionSpec;
 import org.apache.hadoop.hive.metastore.api.PartitionValuesRequest;
-import org.apache.hadoop.hive.metastore.api.PartitionValuesResponse;
 import org.apache.hadoop.hive.metastore.api.PartitionsByExprRequest;
 import org.apache.hadoop.hive.metastore.api.PartitionsByExprResult;
 import org.apache.hadoop.hive.metastore.api.PartitionsStatsRequest;

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/model/DatabaseMappingImpl.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/model/DatabaseMappingImpl.java
@@ -48,6 +48,8 @@ import org.apache.hadoop.hive.metastore.api.LockRequest;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.PartitionSpec;
+import org.apache.hadoop.hive.metastore.api.PartitionValuesRequest;
+import org.apache.hadoop.hive.metastore.api.PartitionValuesResponse;
 import org.apache.hadoop.hive.metastore.api.PartitionsByExprRequest;
 import org.apache.hadoop.hive.metastore.api.PartitionsByExprResult;
 import org.apache.hadoop.hive.metastore.api.PartitionsStatsRequest;
@@ -481,6 +483,12 @@ public class DatabaseMappingImpl implements DatabaseMapping {
       transformOutboundTable(table);
     }
     return result;
+  }
+
+  @Override
+  public PartitionValuesRequest transformInboundPartitionValuesRequest(PartitionValuesRequest req) {
+    req.setDbName(transformInboundDatabaseName(req.getDbName()));
+    return req;
   }
 
   @Override

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/model/DatabaseMappingImpl.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/model/DatabaseMappingImpl.java
@@ -485,9 +485,9 @@ public class DatabaseMappingImpl implements DatabaseMapping {
   }
 
   @Override
-  public PartitionValuesRequest transformInboundPartitionValuesRequest(PartitionValuesRequest req) {
-    req.setDbName(transformInboundDatabaseName(req.getDbName()));
-    return req;
+  public PartitionValuesRequest transformInboundPartitionValuesRequest(PartitionValuesRequest request) {
+    request.setDbName(transformInboundDatabaseName(request.getDbName()));
+    return request;
   }
 
   @Override

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/model/DatabaseMappingImpl.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/model/DatabaseMappingImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,6 @@ import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.PartitionSpec;
 import org.apache.hadoop.hive.metastore.api.PartitionValuesRequest;
-import org.apache.hadoop.hive.metastore.api.PartitionValuesResponse;
 import org.apache.hadoop.hive.metastore.api.PartitionsByExprRequest;
 import org.apache.hadoop.hive.metastore.api.PartitionsByExprResult;
 import org.apache.hadoop.hive.metastore.api.PartitionsStatsRequest;

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/model/IdentityMapping.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/model/IdentityMapping.java
@@ -46,6 +46,7 @@ import org.apache.hadoop.hive.metastore.api.LockRequest;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.PartitionSpec;
+import org.apache.hadoop.hive.metastore.api.PartitionValuesRequest;
 import org.apache.hadoop.hive.metastore.api.PartitionsByExprRequest;
 import org.apache.hadoop.hive.metastore.api.PartitionsByExprResult;
 import org.apache.hadoop.hive.metastore.api.PartitionsStatsRequest;
@@ -348,6 +349,11 @@ public class IdentityMapping implements DatabaseMapping {
   @Override
   public GetTablesResult transformOutboundGetTablesResult(GetTablesResult result) {
     return result;
+  }
+
+  @Override
+  public PartitionValuesRequest transformInboundPartitionValuesRequest(PartitionValuesRequest request) {
+    return request;
   }
 
   @Override

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/model/IdentityMapping.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/mapping/model/IdentityMapping.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/server/FederatedHMSHandler.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/server/FederatedHMSHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/server/FederatedHMSHandler.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/server/FederatedHMSHandler.java
@@ -96,6 +96,8 @@ import org.apache.hadoop.hive.metastore.api.OpenTxnsResponse;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.PartitionEventType;
 import org.apache.hadoop.hive.metastore.api.PartitionSpec;
+import org.apache.hadoop.hive.metastore.api.PartitionValuesRequest;
+import org.apache.hadoop.hive.metastore.api.PartitionValuesResponse;
 import org.apache.hadoop.hive.metastore.api.PartitionsByExprRequest;
 import org.apache.hadoop.hive.metastore.api.PartitionsByExprResult;
 import org.apache.hadoop.hive.metastore.api.PartitionsStatsRequest;
@@ -1670,6 +1672,17 @@ class FederatedHMSHandler extends FacebookBase implements CloseableIHMSHandler {
     DatabaseMapping mapping = databaseMappingService.primaryDatabaseMapping();
     mapping.checkWritePermissions(rqst.getDbname());
     return mapping.getClient().compact2(mapping.transformInboundCompactionRequest(rqst));
+  }
+
+  // Hive 2.3.7 methods
+
+  @Override
+  @Loggable(value = Loggable.DEBUG, skipResult = true, name = INVOCATION_LOG_NAME)
+  public PartitionValuesResponse get_partition_values(PartitionValuesRequest req) throws MetaException, NoSuchObjectException, TException {
+    DatabaseMapping mapping = databaseMappingService.databaseMapping(req.getDbName());
+    return mapping
+        .getClient()
+        .get_partition_values(mapping.transformInboundPartitionValuesRequest(req));
   }
 
 }

--- a/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/server/FederatedHMSHandler.java
+++ b/waggle-dance-core/src/main/java/com/hotels/bdp/waggledance/server/FederatedHMSHandler.java
@@ -1674,7 +1674,7 @@ class FederatedHMSHandler extends FacebookBase implements CloseableIHMSHandler {
     return mapping.getClient().compact2(mapping.transformInboundCompactionRequest(rqst));
   }
 
-  // Hive 2.3.7 methods
+  // Hive 2.3.6 methods
 
   @Override
   @Loggable(value = Loggable.DEBUG, skipResult = true, name = INVOCATION_LOG_NAME)

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/model/DatabaseMappingImplTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/model/DatabaseMappingImplTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2016-2019 Expedia, Inc.
+ * Copyright (C) 2016-2020 Expedia, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/model/DatabaseMappingImplTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/model/DatabaseMappingImplTest.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.DropConstraintRequest;
 import org.apache.hadoop.hive.metastore.api.DropPartitionsRequest;
 import org.apache.hadoop.hive.metastore.api.DropPartitionsResult;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.FireEventRequest;
 import org.apache.hadoop.hive.metastore.api.ForeignKeysRequest;
 import org.apache.hadoop.hive.metastore.api.ForeignKeysResponse;
@@ -820,13 +821,13 @@ public class DatabaseMappingImplTest {
 
   @Test
   public void transformInboundPartitionValuesRequest() {
-    PartitionValuesRequest request = new PartitionValuesRequest();
-    request.setDbName(DB_NAME);
-    request.setTblName(TABLE_NAME);
+    List<FieldSchema> partitionKeys = Collections.singletonList(new FieldSchema());
+    PartitionValuesRequest request = new PartitionValuesRequest(DB_NAME, TABLE_NAME, partitionKeys);
     PartitionValuesRequest transformedRequest = databaseMapping.transformInboundPartitionValuesRequest(request);
     assertThat(transformedRequest, is(sameInstance(request)));
     assertThat(transformedRequest.getDbName(), is(IN_DB_NAME));
     assertThat(transformedRequest.getTblName(), is(TABLE_NAME));
+    assertThat(transformedRequest.getPartitionKeys(), is(sameInstance(partitionKeys)));
   }
 
 }

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/model/DatabaseMappingImplTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/mapping/model/DatabaseMappingImplTest.java
@@ -58,6 +58,7 @@ import org.apache.hadoop.hive.metastore.api.LockComponent;
 import org.apache.hadoop.hive.metastore.api.LockRequest;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.PartitionSpec;
+import org.apache.hadoop.hive.metastore.api.PartitionValuesRequest;
 import org.apache.hadoop.hive.metastore.api.PartitionsByExprRequest;
 import org.apache.hadoop.hive.metastore.api.PartitionsByExprResult;
 import org.apache.hadoop.hive.metastore.api.PartitionsStatsRequest;
@@ -815,6 +816,17 @@ public class DatabaseMappingImplTest {
     assertThat(transformedResult.getTable().getTableName(), is(TABLE_NAME));
     assertThat(transformedResult.getTable().getViewExpandedText(), is(VIEW_EXPANDED_TEXT_TRANSFORMED));
     assertThat(transformedResult.getTable().getViewOriginalText(), is(VIEW_ORIGINAL_TEXT_TRANSFORMED));
+  }
+
+  @Test
+  public void transformInboundPartitionValuesRequest() {
+    PartitionValuesRequest request = new PartitionValuesRequest();
+    request.setDbName(DB_NAME);
+    request.setTblName(TABLE_NAME);
+    PartitionValuesRequest transformedRequest = databaseMapping.transformInboundPartitionValuesRequest(request);
+    assertThat(transformedRequest, is(sameInstance(request)));
+    assertThat(transformedRequest.getDbName(), is(IN_DB_NAME));
+    assertThat(transformedRequest.getTblName(), is(TABLE_NAME));
   }
 
 }

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/server/FederatedHMSHandlerTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/server/FederatedHMSHandlerTest.java
@@ -17,6 +17,7 @@ package com.hotels.bdp.waggledance.server;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -1773,15 +1774,14 @@ public class FederatedHMSHandlerTest {
 
   @Test
   public void get_partition_values() throws TException {
-    Table table = new Table();
-    table.setDbName(DB_P);
-    table.setTableName("table");
-    PartitionValuesRequest request = new PartitionValuesRequest(table.getDbName(), table.getTableName(), Collections.singletonList(new FieldSchema()));
-    PartitionValuesResponse response = new PartitionValuesResponse(Collections.singletonList(new PartitionValuesRow()));
+    PartitionValuesRequest request = new PartitionValuesRequest(DB_P,"table", Collections.singletonList(new FieldSchema()));
+    List<PartitionValuesRow> partitionValues = Collections.singletonList(new PartitionValuesRow());
+    PartitionValuesResponse response = new PartitionValuesResponse(partitionValues);
     when(primaryClient.get_partition_values(request)).thenReturn(response);
     when(primaryMapping.transformInboundPartitionValuesRequest(request)).thenReturn(request);
     PartitionValuesResponse result = handler.get_partition_values(request);
     assertThat(result.getPartitionValuesSize(), is(1));
+    assertThat(result.getPartitionValues(), is(sameInstance(partitionValues)));
   }
 
 }

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/server/FederatedHMSHandlerTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/server/FederatedHMSHandlerTest.java
@@ -1774,7 +1774,7 @@ public class FederatedHMSHandlerTest {
 
   @Test
   public void get_partition_values() throws TException {
-    PartitionValuesRequest request = new PartitionValuesRequest(DB_P,"table", Collections.singletonList(new FieldSchema()));
+    PartitionValuesRequest request = new PartitionValuesRequest(DB_P, "table", Collections.singletonList(new FieldSchema()));
     List<PartitionValuesRow> partitionValues = Collections.singletonList(new PartitionValuesRow());
     PartitionValuesResponse response = new PartitionValuesResponse(partitionValues);
     when(primaryClient.get_partition_values(request)).thenReturn(response);

--- a/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/server/FederatedHMSHandlerTest.java
+++ b/waggle-dance-core/src/test/java/com/hotels/bdp/waggledance/server/FederatedHMSHandlerTest.java
@@ -98,6 +98,9 @@ import org.apache.hadoop.hive.metastore.api.OpenTxnsResponse;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.PartitionEventType;
 import org.apache.hadoop.hive.metastore.api.PartitionSpec;
+import org.apache.hadoop.hive.metastore.api.PartitionValuesRequest;
+import org.apache.hadoop.hive.metastore.api.PartitionValuesResponse;
+import org.apache.hadoop.hive.metastore.api.PartitionValuesRow;
 import org.apache.hadoop.hive.metastore.api.PartitionsByExprRequest;
 import org.apache.hadoop.hive.metastore.api.PartitionsByExprResult;
 import org.apache.hadoop.hive.metastore.api.PartitionsStatsRequest;
@@ -1766,6 +1769,19 @@ public class FederatedHMSHandlerTest {
     when(primaryClient.get_primary_keys(inboundRequest)).thenReturn(response);
     PrimaryKeysResponse result = handler.get_primary_keys(request);
     assertThat(result, is(expected));
+  }
+
+  @Test
+  public void get_partition_values() throws TException {
+    Table table = new Table();
+    table.setDbName(DB_P);
+    table.setTableName("table");
+    PartitionValuesRequest request = new PartitionValuesRequest(table.getDbName(), table.getTableName(), Collections.singletonList(new FieldSchema()));
+    PartitionValuesResponse response = new PartitionValuesResponse(Collections.singletonList(new PartitionValuesRow()));
+    when(primaryClient.get_partition_values(request)).thenReturn(response);
+    when(primaryMapping.transformInboundPartitionValuesRequest(request)).thenReturn(request);
+    PartitionValuesResponse result = handler.get_partition_values(request);
+    assertThat(result.getPartitionValuesSize(), is(1));
   }
 
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch.
* [x] You've successfully built and run the tests locally.
* [x] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/HotelsDotCom/waggle-dance/blob/master/CONTRIBUTING.md
-->

### :pencil: Description
* Upgraded version of `hive.version` to `2.3.7` (was `2.3.3`). Allows Waggle Dance to be used on JDK>=9.
* Implemented `get_partition_values()` method in `FederatedHMSHandler` due to hive version change.

### :link: Related Issues