### PR TITLE
Remove pentaho-aggdesigner-algorithm to fix CodeQL build

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @HotelsDotCom/waggle-dance-committers
+* @HotelsDotCom/apiary-committers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [3.9.5] - TBD
 ### Changed
 * `commons-io` updated to `2.7.` (was `2.6`).
+* `org.pentaho:pentaho-aggdesigner-algorithm` dependency excluded from `waggle-dance-core`.
 
 ## [3.9.4] - 2021-04-08
 ### Fixed

--- a/waggle-dance-core/pom.xml
+++ b/waggle-dance-core/pom.xml
@@ -154,6 +154,10 @@
           <groupId>log4j</groupId>
           <artifactId>log4j</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.pentaho</groupId>
+          <artifactId>pentaho-aggdesigner-algorithm</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 


### PR DESCRIPTION
The CodeQL build started failing yesterday with the following error:
```
   Error: 5-13 07:03:58] [autobuild] [ERROR] Failed to execute goal on project waggle-dance-core: Could not resolve dependencies for project com.hotels:waggle-dance-core:jar:3.9.5-SNAPSHOT: Failed to collect dependencies at org.apache.hive:hive-exec:jar:2.3.7 -> org.apache.calcite:calcite-core:jar:1.10.0 -> org.pentaho:pentaho-aggdesigner-algorithm:jar:5.1.5-jhyde: Failed to read artifact descriptor for org.pentaho:pentaho-aggdesigner-algorithm:jar:5.1.5-jhyde: Could not transfer artifact org.pentaho:pentaho-aggdesigner-algorithm:pom:5.1.5-jhyde from/to maven-default-http-blocker (http://0.0.0.0/): Blocked mirror for repositories: [apache.snapshots (http://repository.apache.org/snapshots, default, snapshots), central (http://repo.maven.apache.org/maven2, default, releases), conjars (http://conjars.org/repo, default, releases+snapshots)] -> [Help 1]
  [2021-05-13 07:03:58] [autobuild] org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal on project waggle-dance-core: Could not resolve dependencies for project com.hotels:waggle-dance-core:jar:3.9.5-SNAPSHOT: Failed to collect dependencies at org.apache.hive:hive-exec:jar:2.3.7 -> org.apache.calcite:calcite-core:jar:1.10.0 -> org.pentaho:pentaho-aggdesigner-algorithm:jar:5.1.5-jhyde
```
I can only assume that GitHub has removed some non-standard Maven repositories from its default allow list as we've seen many problems with this dependency before in other environments. Removing it always seems to fix it and doesn't break anything.